### PR TITLE
fix: CI/CD 배포 시 ECR 인증 토큰 만료 및 .env 한글 파싱 오류 해결.

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -195,7 +195,7 @@ jobs:
           echo "OPENAI_API_KEY=$OPENAI_API_KEY" >> .env
           echo "OPENAI_MODEL=$OPENAI_MODEL" >> .env
           echo "OPENAI_PROMPT=$OPENAI_PROMPT" >> .env
-          echo "OPENAI_POLICY_PROMPT=$OPENAI_POLICY_PROMPT" >> .env
+          echo "OPENAI_POLICY_PROMPT=\"$OPENAI_POLICY_PROMPT\"" >> .env
           echo "USER_INPUT_LIMIT=$USER_INPUT_LIMIT" >> .env
           
           echo "PROJECT_NAME=$PROJECT_NAME" >> .env

--- a/observer/script/docker-deploy.sh
+++ b/observer/script/docker-deploy.sh
@@ -12,6 +12,10 @@ echo "Starting deployment process..."
 echo "Container name: $CONTAINER_NAME"
 echo "Image name: $IMAGE_NAME"
 
+# Authenticate to ECR Public (token expires every 12 hours)
+echo "Logging in to Amazon ECR Public..."
+aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
+
 # Pull the latest image
 echo "Pulling the latest image..."
 docker pull $IMAGE_NAME


### PR DESCRIPTION
## Summary
- `docker-deploy.sh` pull 전 ECR Public 재인증 추가 (토큰 12시간 만료 대응)
- `dev.yml` OPENAI_POLICY_PROMPT 따옴표 처리 (`source .env` 한글 파싱 오류 해결)

## Test plan
- [ ] GitHub Actions dev 워크플로우 실행 후 ECR push 성공 확인
- [ ] EC2 docker pull 성공 및 컨테이너 정상 기동 확인
- [ ] `.env` source 시 `command not found` 에러 미발생 확인

Closes #93