### PR TITLE
[#99]; feat: 프로필에 에겐/테토 유형 필드를 추가한다.

### DIFF
--- a/app/src/main/kotlin/com/yourssu/signal/api/dto/ProfileCreatedRequest.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/api/dto/ProfileCreatedRequest.kt
@@ -34,6 +34,8 @@ data class ProfileCreatedRequest(
     val introSentences: List<String>,
 
     val school: String? = null,
+
+    val egenTeto: String? = null,
 ) {
     fun toCommand(uuid: String): ProfileCreatedCommand {
         return ProfileCreatedCommand(
@@ -47,6 +49,7 @@ data class ProfileCreatedRequest(
             nickname = nickname,
             introSentences = introSentences,
             school = school ?: "숭실대",
+            egenTeto = egenTeto,
         )
     }
 

--- a/app/src/main/kotlin/com/yourssu/signal/api/dto/ProfileUpdateRequest.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/api/dto/ProfileUpdateRequest.kt
@@ -15,6 +15,8 @@ data class ProfileUpdateRequest(
 
     @field:ContactFormat
     val contact: String,
+
+    val egenTeto: String? = null,
 ) {
     fun toCommand(uuid: String): ProfileUpdateCommand {
         return ProfileUpdateCommand(
@@ -22,6 +24,7 @@ data class ProfileUpdateRequest(
             nickname = nickname,
             introSentences = introSentences,
             contact = contact,
+            egenTeto = egenTeto,
         )
     }
 }

--- a/app/src/main/kotlin/com/yourssu/signal/domain/profile/business/ProfileService.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/domain/profile/business/ProfileService.kt
@@ -11,6 +11,7 @@ import com.yourssu.signal.domain.profile.business.dto.ProfileContactResponse
 import com.yourssu.signal.domain.profile.business.dto.ProfileRankingResponse
 import com.yourssu.signal.domain.profile.business.dto.ProfileResponse
 import com.yourssu.signal.domain.profile.implement.*
+import com.yourssu.signal.domain.profile.implement.EgenTeto
 import com.yourssu.signal.domain.user.implement.UserReader
 import com.yourssu.signal.domain.viewer.implement.AdminAccessChecker
 import com.yourssu.signal.domain.viewer.implement.ViewerReader
@@ -54,7 +55,8 @@ class ProfileService(
         val updatedProfile = profile.copy(
             nickname = command.nickname,
             introSentences = command.introSentences,
-            contact = command.contact
+            contact = command.contact,
+            egenTeto = command.egenTeto?.let { EgenTeto.of(it) } ?: profile.egenTeto
         )
         val countContact = profileReader.countContact(command.contact)
         ProfileValidator.checkContactLimit(countContact, policy.contactLimit + 1)

--- a/app/src/main/kotlin/com/yourssu/signal/domain/profile/business/command/ProfileCreatedCommand.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/domain/profile/business/command/ProfileCreatedCommand.kt
@@ -2,6 +2,7 @@ package com.yourssu.signal.domain.profile.business.command
 
 import com.yourssu.signal.domain.common.implement.Uuid
 import com.yourssu.signal.domain.profile.implement.Gender
+import com.yourssu.signal.domain.profile.implement.EgenTeto
 import com.yourssu.signal.domain.profile.implement.Profile
 
 class ProfileCreatedCommand(
@@ -14,7 +15,8 @@ class ProfileCreatedCommand(
     val mbti: String,
     val nickname: String,
     val introSentences: List<String>,
-    val school: String
+    val school: String,
+    val egenTeto: String? = null
 ) {
     fun toUuid(): Uuid {
         return Uuid(uuid)
@@ -32,6 +34,7 @@ class ProfileCreatedCommand(
             nickname = nickname,
             introSentences = introSentences,
             school = school,
+            egenTeto = egenTeto?.let { EgenTeto.of(it) },
         )
     }
 }

--- a/app/src/main/kotlin/com/yourssu/signal/domain/profile/business/command/ProfileUpdateCommand.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/domain/profile/business/command/ProfileUpdateCommand.kt
@@ -5,4 +5,5 @@ data class ProfileUpdateCommand(
     val nickname: String,
     val introSentences: List<String>,
     val contact: String,
+    val egenTeto: String? = null,
 )

--- a/app/src/main/kotlin/com/yourssu/signal/domain/profile/business/dto/MyProfileResponse.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/domain/profile/business/dto/MyProfileResponse.kt
@@ -14,6 +14,7 @@ class MyProfileResponse(
     val nickname: String,
     val introSentences: List<String>,
     val school: String,
+    val egenTeto: String? = null,
 ) {
     companion object {
         fun from(profile: Profile): MyProfileResponse {
@@ -29,6 +30,7 @@ class MyProfileResponse(
                 nickname = profile.nickname,
                 introSentences = profile.introSentences,
                 school = profile.school,
+                egenTeto = profile.egenTeto?.name,
             )
         }
     }

--- a/app/src/main/kotlin/com/yourssu/signal/domain/profile/business/dto/ProfileContactResponse.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/domain/profile/business/dto/ProfileContactResponse.kt
@@ -13,6 +13,7 @@ class ProfileContactResponse(
     val nickname: String,
     val introSentences: List<String>,
     val school: String,
+    val egenTeto: String? = null,
 ) {
     companion object {
         fun from(profile: Profile): ProfileContactResponse {
@@ -27,6 +28,7 @@ class ProfileContactResponse(
                 nickname = profile.nickname,
                 introSentences = profile.introSentences,
                 school = profile.school,
+                egenTeto = profile.egenTeto?.name,
             )
         }
     }

--- a/app/src/main/kotlin/com/yourssu/signal/domain/profile/business/dto/ProfileRankingResponse.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/domain/profile/business/dto/ProfileRankingResponse.kt
@@ -14,7 +14,8 @@ data class ProfileRankingResponse(
     val mbti: String,
     val nickname: String,
     val introSentences: List<String>,
-    val school: String
+    val school: String,
+    val egenTeto: String? = null
 ) {
     companion object {
         fun of(profileRanking: ProfileRanking, profile: Profile, totalProfiles: Int): ProfileRankingResponse {
@@ -29,7 +30,8 @@ data class ProfileRankingResponse(
                 mbti = profile.mbti,
                 nickname = profile.nickname,
                 introSentences = profile.introSentences,
-                school = profile.school
+                school = profile.school,
+                egenTeto = profile.egenTeto?.name
             )
         }
     }

--- a/app/src/main/kotlin/com/yourssu/signal/domain/profile/business/dto/ProfileResponse.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/domain/profile/business/dto/ProfileResponse.kt
@@ -12,6 +12,7 @@ class ProfileResponse(
     val nickname: String,
     val introSentences: List<String>,
     val school: String,
+    val egenTeto: String? = null,
 ) {
     companion object {
         fun from(profile: Profile): ProfileResponse {
@@ -25,6 +26,7 @@ class ProfileResponse(
                 nickname = profile.nickname,
                 introSentences = profile.introSentences,
                 school = profile.school,
+                egenTeto = profile.egenTeto?.name,
             )
         }
     }

--- a/app/src/main/kotlin/com/yourssu/signal/domain/profile/implement/EgenTeto.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/domain/profile/implement/EgenTeto.kt
@@ -1,0 +1,18 @@
+package com.yourssu.signal.domain.profile.implement
+
+import com.yourssu.signal.domain.profile.implement.exception.EgenTetoNotFoundException
+
+enum class EgenTeto {
+    EGEN,
+    TETO,
+    NOT_SELECTED
+    ;
+
+    companion object {
+        fun of(value: String?): EgenTeto? {
+            if (value == null) return null
+            return entries.find { it.name == value.uppercase() }
+                ?: throw EgenTetoNotFoundException()
+        }
+    }
+}

--- a/app/src/main/kotlin/com/yourssu/signal/domain/profile/implement/Profile.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/domain/profile/implement/Profile.kt
@@ -17,6 +17,7 @@ class Profile(
     val nickname: String,
     val introSentences: List<String>,
     val school: String,
+    val egenTeto: EgenTeto? = null,
 ) {
     init {
         validateNickname(nickname)
@@ -24,7 +25,7 @@ class Profile(
         validateBirthYear(birthYear)
     }
 
-    fun copy(introSentences: List<String> = this.introSentences, contact: String = this.contact, nickname: String = this.nickname): Profile {
+    fun copy(introSentences: List<String> = this.introSentences, contact: String = this.contact, nickname: String = this.nickname, egenTeto: EgenTeto? = this.egenTeto): Profile {
         return Profile(
             id = id,
             uuid = uuid,
@@ -36,7 +37,8 @@ class Profile(
             mbti = mbti,
             nickname = nickname,
             introSentences = introSentences,
-            school = school
+            school = school,
+            egenTeto = egenTeto
         )
     }
 }

--- a/app/src/main/kotlin/com/yourssu/signal/domain/profile/implement/exception/EgenTetoNotFoundException.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/domain/profile/implement/exception/EgenTetoNotFoundException.kt
@@ -1,0 +1,6 @@
+package com.yourssu.signal.domain.profile.implement.exception
+
+import com.yourssu.signal.handler.BadRequestException
+
+class EgenTetoNotFoundException: BadRequestException(message = "해당하는 에겐/테토 유형을 찾을 수 없습니다.") {
+}

--- a/app/src/main/kotlin/com/yourssu/signal/domain/profile/storage/ProfileEntity.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/domain/profile/storage/ProfileEntity.kt
@@ -3,6 +3,7 @@ package com.yourssu.signal.domain.profile.storage
 import com.yourssu.signal.domain.common.implement.Uuid
 import com.yourssu.signal.domain.common.storage.BaseEntity
 import com.yourssu.signal.domain.profile.implement.Gender
+import com.yourssu.signal.domain.profile.implement.EgenTeto
 import com.yourssu.signal.domain.profile.implement.Profile
 import jakarta.persistence.*
 
@@ -41,6 +42,10 @@ class ProfileEntity(
 
     @Column(nullable = false)
     val school: String,
+
+    @Column(nullable = true)
+    @Enumerated(EnumType.STRING)
+    val egenTeto: EgenTeto? = null,
 ): BaseEntity() {
     companion object {
         fun from(profile: Profile, encryptedContact: String): ProfileEntity {
@@ -55,6 +60,7 @@ class ProfileEntity(
                 mbti = profile.mbti,
                 nickname = profile.nickname,
                 school = profile.school,
+                egenTeto = profile.egenTeto,
             )
         }
     }
@@ -72,6 +78,7 @@ class ProfileEntity(
             nickname = nickname,
             introSentences = introSentences,
             school = school,
+            egenTeto = egenTeto,
         )
     }
 }

--- a/app/src/test/kotlin/com/yourssu/signal/domain/profile/business/ProfileServiceTest.kt
+++ b/app/src/test/kotlin/com/yourssu/signal/domain/profile/business/ProfileServiceTest.kt
@@ -7,6 +7,7 @@ import com.yourssu.signal.domain.profile.business.command.*
 import com.yourssu.signal.domain.profile.business.dto.DeckResponse
 import com.yourssu.signal.domain.profile.business.ProfilesCountResponse
 import com.yourssu.signal.domain.profile.implement.*
+import com.yourssu.signal.domain.profile.implement.EgenTeto
 import com.yourssu.signal.domain.profile.implement.exception.ContactLimitExceededException
 import com.yourssu.signal.domain.user.implement.User
 import com.yourssu.signal.domain.user.implement.UserReader
@@ -60,7 +61,8 @@ class ProfileServiceTest : DescribeSpec({
             nickname: String = "테스트닉네임",
             contact: String = "@test_contact",
             introSentences: List<String> = listOf("안녕하세요"),
-            gender: Gender = Gender.MALE
+            gender: Gender = Gender.MALE,
+            egenTeto: EgenTeto? = null
         ) = Profile(
             id = id,
             uuid = Uuid(uuid),
@@ -72,7 +74,8 @@ class ProfileServiceTest : DescribeSpec({
             mbti = "ENFP",
             nickname = nickname,
             introSentences = introSentences,
-            school = "숭실대학교"
+            school = "숭실대학교",
+            egenTeto = egenTeto
         )
         
         fun createTestViewer(
@@ -562,6 +565,104 @@ class ProfileServiceTest : DescribeSpec({
                     val result = profileService.getDeck(command)
 
                     result.profiles shouldBe emptyList()
+                }
+            }
+        }
+
+        context("egenTeto 필드 동작") {
+
+            context("프로필 생성 시 egenTeto 없이 요청하면") {
+                it("응답의 egenTeto가 null이다") {
+                    val command = ProfileCreatedCommand(
+                        uuid = "test-uuid",
+                        gender = "MALE",
+                        department = "컴퓨터학부",
+                        birthYear = 2000,
+                        animal = "강아지",
+                        contact = "@test_contact",
+                        mbti = "ENFP",
+                        nickname = "닉네임",
+                        introSentences = listOf("안녕하세요"),
+                        school = "숭실대학교",
+                        egenTeto = null
+                    )
+                    val createdProfile = createTestProfile(egenTeto = null)
+
+                    whenever(userReader.getByUuid(any())).thenReturn(createTestUser())
+                    whenever(profileReader.countContact(any())).thenReturn(0)
+                    whenever(policy.contactLimit).thenReturn(5)
+                    whenever(policy.contactLimitWarning).thenReturn(3)
+                    whenever(profileWriter.createProfile(any())).thenReturn(createdProfile)
+                    whenever(policy.whitelist).thenReturn(false)
+
+                    val result = profileService.createProfile(command)
+
+                    result.egenTeto shouldBe null
+                }
+            }
+
+            context("프로필 생성 시 egenTeto: EGEN으로 요청하면") {
+                it("응답에 EGEN이 반환된다") {
+                    val command = ProfileCreatedCommand(
+                        uuid = "test-uuid",
+                        gender = "MALE",
+                        department = "컴퓨터학부",
+                        birthYear = 2000,
+                        animal = "강아지",
+                        contact = "@test_contact",
+                        mbti = "ENFP",
+                        nickname = "닉네임",
+                        introSentences = listOf("안녕하세요"),
+                        school = "숭실대학교",
+                        egenTeto = "EGEN"
+                    )
+                    val createdProfile = createTestProfile(egenTeto = EgenTeto.EGEN)
+
+                    whenever(userReader.getByUuid(any())).thenReturn(createTestUser())
+                    whenever(profileReader.countContact(any())).thenReturn(0)
+                    whenever(policy.contactLimit).thenReturn(5)
+                    whenever(policy.contactLimitWarning).thenReturn(3)
+                    whenever(profileWriter.createProfile(any())).thenReturn(createdProfile)
+                    whenever(policy.whitelist).thenReturn(false)
+
+                    val result = profileService.createProfile(command)
+
+                    result.egenTeto shouldBe "EGEN"
+                }
+            }
+
+            context("프로필 수정 시 egenTeto: TETO로 요청하면") {
+                it("변경된 TETO가 반영된다") {
+                    val command = ProfileUpdateCommand(
+                        uuid = "test-uuid",
+                        nickname = "닉네임",
+                        introSentences = listOf("안녕하세요"),
+                        contact = "@test_contact",
+                        egenTeto = "TETO"
+                    )
+                    val existingProfile = createTestProfile(egenTeto = null)
+                    val updatedProfile = createTestProfile(egenTeto = EgenTeto.TETO)
+
+                    whenever(profileReader.getByUuid(any())).thenReturn(existingProfile)
+                    whenever(profileReader.countContact(any())).thenReturn(0)
+                    whenever(policy.contactLimit).thenReturn(5)
+                    whenever(profileWriter.updateProfile(any())).thenReturn(updatedProfile)
+
+                    val result = profileService.updateProfile(command)
+
+                    result.egenTeto shouldBe "TETO"
+                }
+            }
+
+            context("egenTeto가 null인 기존 프로필을 조회하면") {
+                it("응답의 egenTeto가 null이다") {
+                    val profile = createTestProfile(egenTeto = null)
+
+                    whenever(profileReader.getByUuid(any())).thenReturn(profile)
+
+                    val result = profileService.getProfile("test-uuid")
+
+                    result.egenTeto shouldBe null
                 }
             }
         }

--- a/app/src/test/kotlin/com/yourssu/signal/domain/profile/implement/EgenTetoTest.kt
+++ b/app/src/test/kotlin/com/yourssu/signal/domain/profile/implement/EgenTetoTest.kt
@@ -1,0 +1,36 @@
+package com.yourssu.signal.domain.profile.implement
+
+import com.yourssu.signal.domain.profile.implement.exception.EgenTetoNotFoundException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+class EgenTetoTest : DescribeSpec({
+    describe("EgenTeto.of") {
+        context("null을 입력하면") {
+            it("null을 반환한다") {
+                EgenTeto.of(null) shouldBe null
+            }
+        }
+
+        context("유효한 값을 입력하면") {
+            it("EGEN을 반환한다") {
+                EgenTeto.of("EGEN") shouldBe EgenTeto.EGEN
+            }
+            it("TETO를 반환한다") {
+                EgenTeto.of("TETO") shouldBe EgenTeto.TETO
+            }
+            it("NOT_SELECTED를 반환한다") {
+                EgenTeto.of("NOT_SELECTED") shouldBe EgenTeto.NOT_SELECTED
+            }
+        }
+
+        context("잘못된 값을 입력하면") {
+            it("EgenTetoNotFoundException을 던진다") {
+                shouldThrow<EgenTetoNotFoundException> {
+                    EgenTeto.of("INVALID")
+                }
+            }
+        }
+    }
+})


### PR DESCRIPTION
<!-- 이슈번호를 작성해주세요 -->
Closes #99

## 요약
- EgenTeto enum 추가 (EGEN / TETO / NOT_SELECTED)
- 프로필 생성·수정 Request에 egenTeto 필드 추가 (선택 사항)
- 모든 프로필 조회 응답 DTO에 egenTeto 필드 추가

## 특이사항
<!-- 구현 시 고려한 사항이나 주의점이 있다면 작성해주세요 -->
- 기존 프로필 데이터 호환: nullable 컬럼, 기존 행은 null 유지