### PR TITLE
[#100]; feat: 닉네임·소개글에 금지어 필터를 적용한다.

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -32,3 +32,6 @@ USER_INPUT_LIMIT=100
 # Ticket policy
 TICKET_PRICE_POLICY=single@1000n1.small@3000n4.best@5000n8
 TICKET_PRICE_REGISTERED_POLICY=single@700n1.small@2100n4.best@3500n8
+
+# Banned words (comma-separated)
+BANNED_WORDS=욕설1,욕설2,욕설3

--- a/app/src/main/kotlin/com/yourssu/signal/api/ProfileController.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/api/ProfileController.kt
@@ -145,7 +145,7 @@ class ProfileController(
         description = "미구매 프로필(가우시안 순서) + 구매된 프로필(구매 순) 전체 목록을 1회 반환합니다.",
         security = [SecurityRequirement(name = "bearerAuth")]
     )
-    @PostMapping("/deck")
+    @GetMapping("/deck")
     @RequireAuth
     fun getDeck(
         @Valid @ModelAttribute request: DeckRequest,

--- a/app/src/main/kotlin/com/yourssu/signal/config/properties/PolicyConfigurationProperties.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/config/properties/PolicyConfigurationProperties.kt
@@ -12,5 +12,6 @@ data class PolicyConfigurationProperties(
     val ticketPricePolicy: String,
     val ticketPriceRegisteredPolicy: String,
     val whitelist: Boolean = false,
+    val bannedWords: List<String> = emptyList(),
 ) {
 }

--- a/app/src/main/kotlin/com/yourssu/signal/domain/profile/business/ProfileService.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/domain/profile/business/ProfileService.kt
@@ -33,6 +33,8 @@ class ProfileService(
 ) {
     fun createProfile(command: ProfileCreatedCommand): MyProfileResponse {
         userReader.getByUuid(command.toUuid())
+        validateBannedWords(command.nickname, command.introSentences)
+
         val profile = command.toDomain()
         val countContact = profileReader.countContact(profile.contact)
         ProfileValidator.checkContactLimit(countContact, policy.contactLimit)
@@ -51,6 +53,8 @@ class ProfileService(
     }
 
     fun updateProfile(command: ProfileUpdateCommand): MyProfileResponse {
+        validateBannedWords(command.nickname, command.introSentences)
+
         val profile = profileReader.getByUuid(Uuid(command.uuid))
         val updatedProfile = profile.copy(
             nickname = command.nickname,
@@ -131,5 +135,11 @@ class ProfileService(
             .map { it.profileId }
         val profiles = profileReader.getByIds(profileIds)
         return profiles.map { it -> ProfileContactResponse.from(it) }
+    }
+
+    private fun validateBannedWords(nickname: String, introSentences: List<String>) {
+        val bannedWords = policy.bannedWords.toSet()
+        ProfileValidator.validateNicknameBannedWord(nickname, bannedWords)
+        ProfileValidator.validateIntroSentencesBannedWord(introSentences, bannedWords)
     }
 }

--- a/app/src/main/kotlin/com/yourssu/signal/domain/profile/implement/BannedWordValidator.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/domain/profile/implement/BannedWordValidator.kt
@@ -1,0 +1,21 @@
+package com.yourssu.signal.domain.profile.implement
+
+import com.yourssu.signal.domain.profile.implement.exception.BannedWordException
+
+private val SPECIAL_CHARS = Regex("[^가-힣a-z0-9]")
+private val REPEATED_CHARS = Regex("(.)\\1+")
+
+object BannedWordValidator {
+    fun validate(text: String, bannedWords: Set<String>) {
+        val normalized = normalize(text)
+        if (bannedWords.any { normalized.contains(it) }) {
+            throw BannedWordException()
+        }
+    }
+
+    private fun normalize(text: String): String {
+        val lower = text.lowercase()
+        val stripped = lower.replace(SPECIAL_CHARS, "")
+        return stripped.replace(REPEATED_CHARS, "$1")
+    }
+}

--- a/app/src/main/kotlin/com/yourssu/signal/domain/profile/implement/ProfileValidator.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/domain/profile/implement/ProfileValidator.kt
@@ -57,4 +57,12 @@ object ProfileValidator {
             Notification.notifyContactExceedsLimitWarning(contactLimitWarning)
         }
     }
+
+    fun validateNicknameBannedWord(nickname: String, bannedWords: Set<String>) {
+        BannedWordValidator.validate(nickname, bannedWords)
+    }
+
+    fun validateIntroSentencesBannedWord(introSentences: List<String>, bannedWords: Set<String>) {
+        introSentences.forEach { BannedWordValidator.validate(it, bannedWords) }
+    }
 }

--- a/app/src/main/kotlin/com/yourssu/signal/domain/profile/implement/exception/BannedWordException.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/domain/profile/implement/exception/BannedWordException.kt
@@ -1,0 +1,5 @@
+package com.yourssu.signal.domain.profile.implement.exception
+
+import com.yourssu.signal.handler.BadRequestException
+
+class BannedWordException : BadRequestException(message = "부적절한 입력입니다.")

--- a/app/src/main/resources/application-dev.yml
+++ b/app/src/main/resources/application-dev.yml
@@ -31,6 +31,7 @@ domain:
     contact-price: ${TICKET_COST}
     ticket-price-policy: ${TICKET_PRICE_POLICY}
     ticket-price-registered-policy: ${TICKET_PRICE_REGISTERED_POLICY}
+    banned-words: ${BANNED_WORDS}
 
 infra:
   openai:

--- a/app/src/main/resources/application-prod.yml
+++ b/app/src/main/resources/application-prod.yml
@@ -31,6 +31,7 @@ domain:
     contact-price: ${TICKET_COST}
     ticket-price-policy: ${TICKET_PRICE_POLICY}
     ticket-price-registered-policy: ${TICKET_PRICE_REGISTERED_POLICY}
+    banned-words: ${BANNED_WORDS}
 
 infra:
   openai:

--- a/app/src/test/kotlin/com/yourssu/signal/domain/profile/business/ProfileServiceTest.kt
+++ b/app/src/test/kotlin/com/yourssu/signal/domain/profile/business/ProfileServiceTest.kt
@@ -8,6 +8,7 @@ import com.yourssu.signal.domain.profile.business.dto.DeckResponse
 import com.yourssu.signal.domain.profile.business.ProfilesCountResponse
 import com.yourssu.signal.domain.profile.implement.*
 import com.yourssu.signal.domain.profile.implement.EgenTeto
+import com.yourssu.signal.domain.profile.implement.exception.BannedWordException
 import com.yourssu.signal.domain.profile.implement.exception.ContactLimitExceededException
 import com.yourssu.signal.domain.user.implement.User
 import com.yourssu.signal.domain.user.implement.UserReader
@@ -90,8 +91,9 @@ class ProfileServiceTest : DescribeSpec({
         )
         
         beforeEach {
-            reset(profileWriter, profileReader, userReader, viewerReader, usedTicketManager, 
+            reset(profileWriter, profileReader, userReader, viewerReader, usedTicketManager,
                   profilePriorityManager, purchasedProfileReader, policy, adminAccessChecker, blacklistWriter)
+            whenever(policy.bannedWords).thenReturn(emptyList())
         }
         
         context("createProfile 메서드를 호출할 때") {
@@ -565,6 +567,87 @@ class ProfileServiceTest : DescribeSpec({
                     val result = profileService.getDeck(command)
 
                     result.profiles shouldBe emptyList()
+                }
+            }
+        }
+
+        context("금지어 검사") {
+
+            context("프로필 생성 시 닉네임에 금지어가 포함되면") {
+                it("BannedWordException을 던진다") {
+                    val command = ProfileCreatedCommand(
+                        uuid = "test-uuid",
+                        gender = "MALE",
+                        department = "컴퓨터학부",
+                        birthYear = 2000,
+                        animal = "강아지",
+                        contact = "@test_contact",
+                        mbti = "ENFP",
+                        nickname = "나쁜말닉네임",
+                        introSentences = listOf("안녕하세요"),
+                        school = "숭실대학교"
+                    )
+                    whenever(userReader.getByUuid(any())).thenReturn(createTestUser())
+                    whenever(policy.bannedWords).thenReturn(listOf("나쁜말"))
+
+                    shouldThrow<BannedWordException> {
+                        profileService.createProfile(command)
+                    }
+                }
+            }
+
+            context("프로필 생성 시 소개글에 금지어가 포함되면") {
+                it("BannedWordException을 던진다") {
+                    val command = ProfileCreatedCommand(
+                        uuid = "test-uuid",
+                        gender = "MALE",
+                        department = "컴퓨터학부",
+                        birthYear = 2000,
+                        animal = "강아지",
+                        contact = "@test_contact",
+                        mbti = "ENFP",
+                        nickname = "정상닉네임",
+                        introSentences = listOf("badword 포함 소개"),
+                        school = "숭실대학교"
+                    )
+                    whenever(userReader.getByUuid(any())).thenReturn(createTestUser())
+                    whenever(policy.bannedWords).thenReturn(listOf("badword"))
+
+                    shouldThrow<BannedWordException> {
+                        profileService.createProfile(command)
+                    }
+                }
+            }
+
+            context("프로필 수정 시 닉네임에 금지어가 포함되면") {
+                it("BannedWordException을 던진다") {
+                    val command = ProfileUpdateCommand(
+                        uuid = "test-uuid",
+                        nickname = "나쁜말닉네임",
+                        introSentences = listOf("안녕하세요"),
+                        contact = "@test_contact"
+                    )
+                    whenever(policy.bannedWords).thenReturn(listOf("나쁜말"))
+
+                    shouldThrow<BannedWordException> {
+                        profileService.updateProfile(command)
+                    }
+                }
+            }
+
+            context("프로필 수정 시 소개글에 금지어가 포함되면") {
+                it("BannedWordException을 던진다") {
+                    val command = ProfileUpdateCommand(
+                        uuid = "test-uuid",
+                        nickname = "정상닉네임",
+                        introSentences = listOf("안녕", "badword 섞인 소개"),
+                        contact = "@test_contact"
+                    )
+                    whenever(policy.bannedWords).thenReturn(listOf("badword"))
+
+                    shouldThrow<BannedWordException> {
+                        profileService.updateProfile(command)
+                    }
                 }
             }
         }

--- a/app/src/test/kotlin/com/yourssu/signal/domain/profile/implement/BannedWordValidatorTest.kt
+++ b/app/src/test/kotlin/com/yourssu/signal/domain/profile/implement/BannedWordValidatorTest.kt
@@ -1,0 +1,68 @@
+package com.yourssu.signal.domain.profile.implement
+
+import com.yourssu.signal.domain.profile.implement.exception.BannedWordException
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+
+class BannedWordValidatorTest : DescribeSpec({
+    describe("BannedWordValidator.validate") {
+        val bannedWords = setOf("나쁜말", "badword")
+
+        context("금지어가 없는 텍스트를 입력하면") {
+            it("예외를 던지지 않는다") {
+                shouldNotThrowAny {
+                    BannedWordValidator.validate("안녕하세요", bannedWords)
+                }
+            }
+        }
+
+        context("금지어가 포함된 텍스트를 입력하면") {
+            it("BannedWordException을 던진다") {
+                shouldThrow<BannedWordException> {
+                    BannedWordValidator.validate("나쁜말닉네임", bannedWords)
+                }
+            }
+        }
+
+        context("반복 문자로 금지어를 변형하면") {
+            it("정규화 후 BannedWordException을 던진다") {
+                shouldThrow<BannedWordException> {
+                    BannedWordValidator.validate("나나쁜말", bannedWords)
+                }
+            }
+        }
+
+        context("공백을 섞어 금지어를 변형하면") {
+            it("정규화 후 BannedWordException을 던진다") {
+                shouldThrow<BannedWordException> {
+                    BannedWordValidator.validate("나쁜 말", bannedWords)
+                }
+            }
+        }
+
+        context("특수문자를 섞어 금지어를 변형하면") {
+            it("정규화 후 BannedWordException을 던진다") {
+                shouldThrow<BannedWordException> {
+                    BannedWordValidator.validate("나쁜.말", bannedWords)
+                }
+            }
+        }
+
+        context("영어 금지어를 대문자로 입력하면") {
+            it("소문자 변환 후 BannedWordException을 던진다") {
+                shouldThrow<BannedWordException> {
+                    BannedWordValidator.validate("BADWORD", bannedWords)
+                }
+            }
+        }
+
+        context("빈 금지어 Set으로 검사하면") {
+            it("예외를 던지지 않는다") {
+                shouldNotThrowAny {
+                    BannedWordValidator.validate("나쁜말", emptySet())
+                }
+            }
+        }
+    }
+})


### PR DESCRIPTION
<!-- 이슈번호를 작성해주세요 -->
Closes #100

## 요약
- BannedWordValidator 추가: 공백·특수문자 제거 + 반복문자 압축 정규화 후 금지어 Set 비교
- ProfileService의 프로필 생성·수정 시 닉네임·소개글 금지어 검사 적용
- 금지어 목록은 .env BANNED_WORDS 환경변수로 관리 (application.yml에서 바인딩)

## 특이사항
<!-- 구현 시 고려한 사항이나 주의점이 있다면 작성해주세요 -->
- 