### PR TITLE
[#102]; feat: 프로필 조회 시 궁합 라벨을 반환한다.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ Thumbs.db
 /signal-api-2025-2
 /signal-api-2025-1
 /ref
+/usecase

--- a/app/src/main/kotlin/com/yourssu/signal/api/ProfileController.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/api/ProfileController.kt
@@ -15,6 +15,7 @@ import com.yourssu.signal.domain.profile.business.dto.MyProfileResponse
 import com.yourssu.signal.domain.profile.business.dto.ProfileContactResponse
 import com.yourssu.signal.domain.profile.business.dto.ProfileRankingResponse
 import com.yourssu.signal.domain.profile.business.dto.DeckResponse
+import com.yourssu.signal.domain.profile.business.dto.EgenTetoStatsResponse
 import com.yourssu.signal.domain.profile.business.dto.ProfileResponse
 import com.yourssu.signal.api.dto.RandomProfileRequest
 import io.swagger.v3.oas.annotations.Operation
@@ -84,6 +85,16 @@ class ProfileController(
     @GetMapping
     fun getAllProfiles(@Valid @ModelAttribute request: ProfilesFoundRequest): ResponseEntity<Response<List<ProfileResponse>>> {
         val response = profileService.getAllProfiles(request.toCommand())
+        return ResponseEntity.ok(Response(result = response))
+    }
+
+    @Operation(
+        summary = "에겐/테토 통계 조회",
+        description = "에겐·테토별 등록자 수와 비율을 조회합니다."
+    )
+    @GetMapping("/egenteto/stats")
+    fun getEgenTetoStats(): ResponseEntity<Response<EgenTetoStatsResponse>> {
+        val response = profileService.getEgenTetoStats()
         return ResponseEntity.ok(Response(result = response))
     }
 

--- a/app/src/main/kotlin/com/yourssu/signal/domain/profile/business/ProfileService.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/domain/profile/business/ProfileService.kt
@@ -6,6 +6,7 @@ import com.yourssu.signal.domain.blacklist.implement.BlacklistWriter
 import com.yourssu.signal.domain.common.implement.Uuid
 import com.yourssu.signal.domain.profile.business.command.*
 import com.yourssu.signal.domain.profile.business.dto.DeckResponse
+import com.yourssu.signal.domain.profile.business.dto.EgenTetoStatsResponse
 import com.yourssu.signal.domain.profile.business.dto.MyProfileResponse
 import com.yourssu.signal.domain.profile.business.dto.ProfileContactResponse
 import com.yourssu.signal.domain.profile.business.dto.ProfileRankingResponse
@@ -69,11 +70,11 @@ class ProfileService(
     }
 
     fun getDeck(command: DeckCommand): DeckResponse {
-        val myProfileId = if (profileReader.existsByUuid(Uuid(command.uuid)))
-            profileReader.getByUuid(Uuid(command.uuid)).id
+        val myProfile = if (profileReader.existsByUuid(Uuid(command.uuid)))
+            profileReader.getByUuid(Uuid(command.uuid))
         else null
-        val orderedIds = profilePriorityManager.buildDeck(myProfileId, Gender.of(command.gender))
-        return DeckResponse.from(profileReader.getOrderedByIds(orderedIds))
+        val orderedIds = profilePriorityManager.buildDeck(myProfile?.id, Gender.of(command.gender))
+        return DeckResponse.from(profileReader.getOrderedByIds(orderedIds), myProfile)
     }
 
     fun getRandomProfile(command: RandomProfileFoundCommand): ProfileResponse {
@@ -82,7 +83,7 @@ class ProfileService(
         if (profileReader.existsByUuid(uuid)) {
             val myProfile = profileReader.getByUuid(uuid)
             val profile = profilePriorityManager.pickRandomProfile(command.toExcludeProfiles(myProfile), gender)
-            return ProfileResponse.from(profile)
+            return ProfileResponse.from(profile, myProfile)
         }
         val profile = profilePriorityManager.pickRandomProfile(command.toExcludeProfiles(), gender)
         return ProfileResponse.from(profile)
@@ -135,6 +136,13 @@ class ProfileService(
             .map { it.profileId }
         val profiles = profileReader.getByIds(profileIds)
         return profiles.map { it -> ProfileContactResponse.from(it) }
+    }
+
+    fun getEgenTetoStats(): EgenTetoStatsResponse {
+        val egenCount = profileReader.countByEgenTeto(EgenTeto.EGEN)
+        val tetoCount = profileReader.countByEgenTeto(EgenTeto.TETO)
+        val total = profileReader.countAll()
+        return EgenTetoStatsResponse.of(egenCount, tetoCount, total)
     }
 
     private fun validateBannedWords(nickname: String, introSentences: List<String>) {

--- a/app/src/main/kotlin/com/yourssu/signal/domain/profile/business/dto/DeckResponse.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/domain/profile/business/dto/DeckResponse.kt
@@ -6,8 +6,8 @@ class DeckResponse(
     val profiles: List<ProfileResponse>,
 ) {
     companion object {
-        fun from(profiles: List<Profile>) = DeckResponse(
-            profiles = profiles.map { ProfileResponse.from(it) }
+        fun from(profiles: List<Profile>, myProfile: Profile? = null) = DeckResponse(
+            profiles = profiles.map { ProfileResponse.from(it, myProfile) }
         )
     }
 }

--- a/app/src/main/kotlin/com/yourssu/signal/domain/profile/business/dto/EgenTetoStatsResponse.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/domain/profile/business/dto/EgenTetoStatsResponse.kt
@@ -1,0 +1,27 @@
+package com.yourssu.signal.domain.profile.business.dto
+
+import kotlin.math.round
+
+class EgenTetoStatsResponse(
+    val egenCount: Int,
+    val tetoCount: Int,
+    val total: Int,
+    val egenRatio: Double,
+    val tetoRatio: Double,
+) {
+    companion object {
+        fun of(egenCount: Int, tetoCount: Int, total: Int): EgenTetoStatsResponse {
+            val selectedTotal = egenCount + tetoCount
+            return EgenTetoStatsResponse(
+                egenCount = egenCount,
+                tetoCount = tetoCount,
+                total = total,
+                egenRatio = ratio(egenCount, selectedTotal),
+                tetoRatio = ratio(tetoCount, selectedTotal),
+            )
+        }
+
+        private fun ratio(count: Int, selectedTotal: Int): Double =
+            if (selectedTotal == 0) 0.0 else round(count.toDouble() / selectedTotal * 1000) / 10
+    }
+}

--- a/app/src/main/kotlin/com/yourssu/signal/domain/profile/business/dto/ProfileResponse.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/domain/profile/business/dto/ProfileResponse.kt
@@ -1,5 +1,6 @@
 package com.yourssu.signal.domain.profile.business.dto
 
+import com.yourssu.signal.domain.profile.implement.CompatibilityMatcher
 import com.yourssu.signal.domain.profile.implement.Profile
 
 class ProfileResponse(
@@ -13,9 +14,10 @@ class ProfileResponse(
     val introSentences: List<String>,
     val school: String,
     val egenTeto: String? = null,
+    val compatibilityLabel: String? = null,
 ) {
     companion object {
-        fun from(profile: Profile): ProfileResponse {
+        fun from(profile: Profile, myProfile: Profile? = null): ProfileResponse {
             return ProfileResponse(
                 profileId = profile.id!!,
                 gender = profile.gender.name,
@@ -27,6 +29,7 @@ class ProfileResponse(
                 introSentences = profile.introSentences,
                 school = profile.school,
                 egenTeto = profile.egenTeto?.name,
+                compatibilityLabel = myProfile?.let { CompatibilityMatcher.match(it, profile)?.message },
             )
         }
     }

--- a/app/src/main/kotlin/com/yourssu/signal/domain/profile/implement/AnimalCompatibilityTable.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/domain/profile/implement/AnimalCompatibilityTable.kt
@@ -1,0 +1,30 @@
+package com.yourssu.signal.domain.profile.implement
+
+object AnimalCompatibilityTable {
+
+    // 여자 동물상 기준: 내 동물 → 매칭되는 남자 동물
+    private val femaleTable = mapOf(
+        "고양이" to setOf("강아지", "곰"),
+        "강아지" to setOf("고양이", "공룡"),
+        "햄스터" to setOf("곰", "햄스터"),
+        "여우" to setOf("공룡", "사슴"),
+        "토끼" to setOf("사슴", "강아지"),
+        "꼬부기" to setOf("햄스터", "고양이"),
+    )
+
+    // 남자 동물상 기준: 내 동물 → 매칭되는 여자 동물
+    private val maleTable = mapOf(
+        "고양이" to setOf("강아지", "꼬부기"),
+        "강아지" to setOf("고양이", "토끼"),
+        "햄스터" to setOf("꼬부기", "햄스터"),
+        "공룡" to setOf("여우", "강아지"),
+        "곰" to setOf("햄스터", "고양이"),
+        "사슴" to setOf("토끼", "여우"),
+    )
+
+    fun isCompatible(myProfile: Profile, targetProfile: Profile): Boolean =
+        if (myProfile.gender == Gender.FEMALE)
+            femaleTable[myProfile.animal]?.contains(targetProfile.animal) == true
+        else
+            maleTable[myProfile.animal]?.contains(targetProfile.animal) == true
+}

--- a/app/src/main/kotlin/com/yourssu/signal/domain/profile/implement/CompatibilityLabel.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/domain/profile/implement/CompatibilityLabel.kt
@@ -1,0 +1,7 @@
+package com.yourssu.signal.domain.profile.implement
+
+enum class CompatibilityLabel(val message: String) {
+    PERFECT_MATCH("찰떡 궁합 PICK 내 운명의 상대... 이 사람일지도?"),
+    MBTI_MATCH("MBTI 궁합 PICK 생각이 통하는 상대... 이 사람일지도?"),
+    ANIMAL_MATCH("동물상 궁합 PICK 분위기가 맞는 상대... 이 사람일지도?"),
+}

--- a/app/src/main/kotlin/com/yourssu/signal/domain/profile/implement/CompatibilityMatcher.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/domain/profile/implement/CompatibilityMatcher.kt
@@ -8,7 +8,8 @@ object CompatibilityMatcher {
         val animalMatch = AnimalCompatibilityTable.isCompatible(myProfile, targetProfile)
         return when {
             mbtiMatch && animalMatch -> CompatibilityLabel.PERFECT_MATCH
-            mbtiMatch || animalMatch -> CompatibilityLabel.GOOD_MATCH
+            mbtiMatch -> CompatibilityLabel.MBTI_MATCH
+            animalMatch -> CompatibilityLabel.ANIMAL_MATCH
             else -> null
         }
     }

--- a/app/src/main/kotlin/com/yourssu/signal/domain/profile/implement/CompatibilityMatcher.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/domain/profile/implement/CompatibilityMatcher.kt
@@ -1,0 +1,21 @@
+package com.yourssu.signal.domain.profile.implement
+
+object CompatibilityMatcher {
+
+    fun match(myProfile: Profile, targetProfile: Profile): CompatibilityLabel? {
+        if (!isAgeCompatible(myProfile, targetProfile)) return null
+        val mbtiMatch = MbtiCompatibilityTable.isCompatible(myProfile.mbti, targetProfile.mbti)
+        val animalMatch = AnimalCompatibilityTable.isCompatible(myProfile, targetProfile)
+        return when {
+            mbtiMatch && animalMatch -> CompatibilityLabel.PERFECT_MATCH
+            mbtiMatch || animalMatch -> CompatibilityLabel.GOOD_MATCH
+            else -> null
+        }
+    }
+
+    private fun isAgeCompatible(myProfile: Profile, targetProfile: Profile): Boolean {
+        val (male, female) = if (myProfile.gender == Gender.MALE) myProfile to targetProfile
+        else targetProfile to myProfile
+        return male.birthYear in (female.birthYear - 3)..female.birthYear
+    }
+}

--- a/app/src/main/kotlin/com/yourssu/signal/domain/profile/implement/MbtiCompatibilityTable.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/domain/profile/implement/MbtiCompatibilityTable.kt
@@ -1,0 +1,26 @@
+package com.yourssu.signal.domain.profile.implement
+
+object MbtiCompatibilityTable {
+
+    private val table = mapOf(
+        "INFP" to setOf("ENFJ", "ENTJ"),
+        "ENFP" to setOf("INFJ", "INTJ"),
+        "INFJ" to setOf("ENFP", "ENTP"),
+        "ENFJ" to setOf("INFP", "ISFP"),
+        "INTJ" to setOf("ENFP", "ENTP"),
+        "ENTJ" to setOf("INFP", "INTP"),
+        "INTP" to setOf("ENTJ", "ESTJ"),
+        "ENTP" to setOf("INFJ", "INTJ"),
+        "ISFP" to setOf("ENFJ", "ESFJ"),
+        "ESFP" to setOf("ISFJ", "ISTJ"),
+        "ISTP" to setOf("ESFJ", "ESTJ"),
+        "ESTP" to setOf("ISFJ", "ISTJ"),
+        "ISFJ" to setOf("ESFP", "ESTP"),
+        "ESFJ" to setOf("ISFP", "ISTP"),
+        "ISTJ" to setOf("ESFP", "ESTP"),
+        "ESTJ" to setOf("INTP", "ISFP"),
+    )
+
+    fun isCompatible(my: String, target: String): Boolean =
+        table[my]?.contains(target) == true
+}

--- a/app/src/main/kotlin/com/yourssu/signal/domain/profile/implement/ProfileReader.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/domain/profile/implement/ProfileReader.kt
@@ -51,6 +51,10 @@ class ProfileReader(
         return profileRepository.findBy(profiles)
     }
 
+    fun countByEgenTeto(egenTeto: EgenTeto): Int {
+        return profileRepository.countByEgenTeto(egenTeto)
+    }
+
     fun getOrderedByIds(orderedIds: List<Long>): List<Profile> {
         if (orderedIds.isEmpty()) return emptyList()
         val profiles = profileRepository.findBy(orderedIds).associateBy { it.id!! }

--- a/app/src/main/kotlin/com/yourssu/signal/domain/profile/implement/ProfileRepository.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/domain/profile/implement/ProfileRepository.kt
@@ -12,4 +12,5 @@ interface ProfileRepository {
     fun updateCacheIdsByGender(gender: Gender): List<Long>
     fun getById(id: Long): Profile
     fun findBy(profiles: List<Long>): List<Profile>
+    fun countByEgenTeto(egenTeto: EgenTeto): Int
 }

--- a/app/src/main/kotlin/com/yourssu/signal/domain/profile/storage/ProfileRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/domain/profile/storage/ProfileRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.yourssu.signal.domain.profile.storage
 import com.querydsl.jpa.impl.JPAQueryFactory
 import com.yourssu.signal.config.security.DataCipher
 import com.yourssu.signal.domain.common.implement.Uuid
+import com.yourssu.signal.domain.profile.implement.EgenTeto
 import com.yourssu.signal.domain.profile.implement.ProfileRepository
 import com.yourssu.signal.domain.profile.implement.Gender
 import com.yourssu.signal.domain.profile.implement.Profile
@@ -77,6 +78,10 @@ class ProfileRepositoryImpl(
             .fetch()
     }
 
+    override fun countByEgenTeto(egenTeto: EgenTeto): Int {
+        return profileJpaRepository.countByEgenTeto(egenTeto).toInt()
+    }
+
     private fun decryptContact(profile: Profile): Profile {
         return profile.copy(
             contact = dataCipher.decrypt(profile.contact)
@@ -84,5 +89,6 @@ class ProfileRepositoryImpl(
     }
 }
 
-interface ProfileJpaRepository: JpaRepository<ProfileEntity, Long> {
+interface ProfileJpaRepository : JpaRepository<ProfileEntity, Long> {
+    fun countByEgenTeto(egenTeto: EgenTeto): Long
 }

--- a/app/src/test/kotlin/com/yourssu/signal/domain/profile/implement/CompatibilityMatcherTest.kt
+++ b/app/src/test/kotlin/com/yourssu/signal/domain/profile/implement/CompatibilityMatcherTest.kt
@@ -1,0 +1,140 @@
+package com.yourssu.signal.domain.profile.implement
+
+import com.yourssu.signal.domain.common.implement.Uuid
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+private val PERFECT = CompatibilityLabel.PERFECT_MATCH
+private val GOOD = CompatibilityLabel.GOOD_MATCH
+
+class CompatibilityMatcherTest : DescribeSpec({
+
+    fun male(mbti: String, animal: String, birthYear: Int = 2000) = Profile(
+        id = 1L,
+        uuid = Uuid.randomUUID(),
+        gender = Gender.MALE,
+        department = "컴퓨터학부",
+        birthYear = birthYear,
+        animal = animal,
+        contact = "@male",
+        mbti = mbti,
+        nickname = "남자",
+        introSentences = emptyList(),
+        school = "숭실대학교",
+    )
+
+    fun female(mbti: String, animal: String, birthYear: Int = 2001) = Profile(
+        id = 2L,
+        uuid = Uuid.randomUUID(),
+        gender = Gender.FEMALE,
+        department = "컴퓨터학부",
+        birthYear = birthYear,
+        animal = animal,
+        contact = "@female",
+        mbti = mbti,
+        nickname = "여자",
+        introSentences = emptyList(),
+        school = "숭실대학교",
+    )
+
+    describe("CompatibilityMatcher.match") {
+
+        context("나이 조건 검사") {
+            it("남자가 동갑이면 나이 조건을 만족한다") {
+                // male 2001, female 2001 → 동갑
+                val m = male("INFP", "강아지", 2001)
+                val f = female("ENFJ", "고양이", 2001)
+                CompatibilityMatcher.match(m, f) shouldBe PERFECT
+            }
+
+            it("남자가 3살 연상이면 나이 조건을 만족한다") {
+                // male 1998, female 2001 → 3살 연상
+                val m = male("INFP", "강아지", 1998)
+                val f = female("ENFJ", "고양이", 2001)
+                CompatibilityMatcher.match(m, f) shouldBe PERFECT
+            }
+
+            it("남자가 4살 이상 연상이면 null 반환") {
+                val m = male("INFP", "강아지", 1997)
+                val f = female("ENFJ", "고양이", 2001)
+                CompatibilityMatcher.match(m, f) shouldBe null
+            }
+
+            it("남자가 연하이면 null 반환") {
+                val m = male("INFP", "강아지", 2003)
+                val f = female("ENFJ", "고양이", 2001)
+                CompatibilityMatcher.match(m, f) shouldBe null
+            }
+
+            it("여자 기준으로 남자가 동갑~3살 연상 조건을 정확히 검증한다") {
+                // female 기준으로 myProfile=female인 경우도 동일하게 동작해야 함
+                val f = female("INFP", "고양이", 2001)
+                val m = male("ENFJ", "강아지", 1998) // 3살 연상
+                CompatibilityMatcher.match(f, m) shouldBe PERFECT
+            }
+        }
+
+        context("MBTI와 동물상이 모두 맞으면") {
+            it("PERFECT_MATCH 반환 (여자 기준)") {
+                // 여자: INFP+고양이, 남자: ENFJ+강아지
+                val f = female("INFP", "고양이", 2001)
+                val m = male("ENFJ", "강아지", 2000)
+                CompatibilityMatcher.match(f, m) shouldBe PERFECT
+            }
+
+            it("PERFECT_MATCH 반환 (남자 기준)") {
+                // 남자: INFP+강아지, 여자: ENFJ+고양이
+                val m = male("INFP", "강아지", 2000)
+                val f = female("ENFJ", "고양이", 2001)
+                CompatibilityMatcher.match(m, f) shouldBe PERFECT
+            }
+        }
+
+        context("MBTI만 맞고 동물상은 안 맞으면") {
+            it("GOOD_MATCH 반환") {
+                // 여자: INFP+여우, 남자: ENFJ+강아지 → MBTI 맞음, 동물상 여우→[공룡,사슴] 미매칭
+                val f = female("INFP", "여우", 2001)
+                val m = male("ENFJ", "강아지", 2000)
+                CompatibilityMatcher.match(f, m) shouldBe GOOD
+            }
+        }
+
+        context("동물상만 맞고 MBTI는 안 맞으면") {
+            it("GOOD_MATCH 반환") {
+                // 여자: ENFP+고양이, 남자: ENFJ+강아지 → 동물상 고양이→[강아지,곰] 맞음, MBTI ENFP→[INFJ,INTJ] 미매칭
+                val f = female("ENFP", "고양이", 2001)
+                val m = male("ENFJ", "강아지", 2000)
+                CompatibilityMatcher.match(f, m) shouldBe GOOD
+            }
+        }
+
+        context("MBTI와 동물상 모두 안 맞으면") {
+            it("null 반환") {
+                // 여자: ENFP+여우, 남자: ENFJ+강아지 → 둘 다 미매칭
+                val f = female("ENFP", "여우", 2001)
+                val m = male("ENFJ", "강아지", 2000)
+                CompatibilityMatcher.match(f, m) shouldBe null
+            }
+        }
+
+        context("동물상 궁합 검증") {
+            it("햄스터(여)+햄스터(남)은 매칭된다") {
+                val f = female("ENFP", "햄스터", 2001)
+                val m = male("INFJ", "햄스터", 2001)
+                CompatibilityMatcher.match(f, m) shouldBe PERFECT
+            }
+
+            it("꼬부기(여)+햄스터(남)은 매칭된다") {
+                val f = female("ENFP", "꼬부기", 2001)
+                val m = male("INFJ", "햄스터", 2001)
+                CompatibilityMatcher.match(f, m) shouldBe PERFECT
+            }
+
+            it("토끼(여)+사슴(남)은 매칭된다") {
+                val f = female("ENFP", "토끼", 2001)
+                val m = male("INFJ", "사슴", 2001)
+                CompatibilityMatcher.match(f, m) shouldBe PERFECT
+            }
+        }
+    }
+})

--- a/app/src/test/kotlin/com/yourssu/signal/domain/profile/implement/CompatibilityMatcherTest.kt
+++ b/app/src/test/kotlin/com/yourssu/signal/domain/profile/implement/CompatibilityMatcherTest.kt
@@ -5,7 +5,8 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 
 private val PERFECT = CompatibilityLabel.PERFECT_MATCH
-private val GOOD = CompatibilityLabel.GOOD_MATCH
+private val MBTI = CompatibilityLabel.MBTI_MATCH
+private val ANIMAL = CompatibilityLabel.ANIMAL_MATCH
 
 class CompatibilityMatcherTest : DescribeSpec({
 
@@ -91,20 +92,20 @@ class CompatibilityMatcherTest : DescribeSpec({
         }
 
         context("MBTI만 맞고 동물상은 안 맞으면") {
-            it("GOOD_MATCH 반환") {
+            it("MBTI_MATCH 반환") {
                 // 여자: INFP+여우, 남자: ENFJ+강아지 → MBTI 맞음, 동물상 여우→[공룡,사슴] 미매칭
                 val f = female("INFP", "여우", 2001)
                 val m = male("ENFJ", "강아지", 2000)
-                CompatibilityMatcher.match(f, m) shouldBe GOOD
+                CompatibilityMatcher.match(f, m) shouldBe MBTI
             }
         }
 
         context("동물상만 맞고 MBTI는 안 맞으면") {
-            it("GOOD_MATCH 반환") {
+            it("ANIMAL_MATCH 반환") {
                 // 여자: ENFP+고양이, 남자: ENFJ+강아지 → 동물상 고양이→[강아지,곰] 맞음, MBTI ENFP→[INFJ,INTJ] 미매칭
                 val f = female("ENFP", "고양이", 2001)
                 val m = male("ENFJ", "강아지", 2000)
-                CompatibilityMatcher.match(f, m) shouldBe GOOD
+                CompatibilityMatcher.match(f, m) shouldBe ANIMAL
             }
         }
 


### PR DESCRIPTION
<!-- 이슈번호를 작성해주세요 -->
Closes #102 #104

## 요약
- MBTI × 동물상 × 나이 조건 기반 궁합 매칭 로직 구현 (CompatibilityMatcher, MbtiCompatibilityTable, AnimalCompatibilityTable)
- 덱 조회(GET /api/profiles/deck) 응답의 ProfileResponse에 compatibilityLabel 필드 추가
- 에겐/테토별 등록자 수·비율 조회 API 추가 (GET /api/profiles/egenteto/stats)

## 특이사항
<!-- 구현 시 고려한 사항이나 주의점이 있다면 작성해주세요 -->
- 