### PR TITLE
[#110]; fix: 신규 유저 register 시 Viewer 자동 생성.

### DIFF
--- a/app/src/main/kotlin/com/yourssu/signal/domain/auth/business/AuthService.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/domain/auth/business/AuthService.kt
@@ -16,6 +16,7 @@ import com.yourssu.signal.domain.common.implement.Uuid
 import com.yourssu.signal.domain.user.implement.User
 import com.yourssu.signal.domain.user.implement.UserReader
 import com.yourssu.signal.domain.user.implement.UserWriter
+import com.yourssu.signal.domain.viewer.implement.ViewerWriter
 import com.yourssu.signal.domain.viewer.implement.exception.AdminPermissionDeniedException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -30,10 +31,12 @@ class AuthService(
     private val googleUserReader: GoogleUserReader,
     private val googleUserWriter: GoogleUserWriter,
     private val oAuthOutputPort: OAuthOutputPort,
+    private val viewerWriter: ViewerWriter,
 ) {
     @Transactional
     fun register(): TokenResponse {
         val user = userWriter.generateUser()
+        viewerWriter.create(user.uuid)
         return generateTokenResponse(user)
     }
 

--- a/app/src/main/kotlin/com/yourssu/signal/domain/viewer/implement/ViewerWriter.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/domain/viewer/implement/ViewerWriter.kt
@@ -9,6 +9,11 @@ class ViewerWriter(
     private val viewerRepository: ViewerRepository,
 ) {
     @Transactional
+    fun create(uuid: Uuid): Viewer {
+        return createViewer(uuid, 0)
+    }
+
+    @Transactional
     fun issueTicket(uuid: Uuid, ticket: Int): Viewer {
         if (viewerRepository.existsByUuid(uuid)) {
             val viewer = viewerRepository.getByUuid(uuid)

--- a/app/src/test/kotlin/com/yourssu/signal/domain/auth/business/AuthServiceTest.kt
+++ b/app/src/test/kotlin/com/yourssu/signal/domain/auth/business/AuthServiceTest.kt
@@ -13,6 +13,8 @@ import com.yourssu.signal.domain.common.implement.Uuid
 import com.yourssu.signal.domain.user.implement.User
 import com.yourssu.signal.domain.user.implement.UserReader
 import com.yourssu.signal.domain.user.implement.UserWriter
+import com.yourssu.signal.domain.viewer.implement.Viewer
+import com.yourssu.signal.domain.viewer.implement.ViewerWriter
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
@@ -28,6 +30,7 @@ class AuthServiceTest : DescribeSpec({
     val googleUserReader = mock<GoogleUserReader>()
     val googleUserWriter = mock<GoogleUserWriter>()
     val oAuthOutputPort = mock<OAuthOutputPort>()
+    val viewerWriter = mock<ViewerWriter>()
 
     val authService = AuthService(
         jwtUtils = jwtUtils,
@@ -38,6 +41,7 @@ class AuthServiceTest : DescribeSpec({
         googleUserReader = googleUserReader,
         googleUserWriter = googleUserWriter,
         oAuthOutputPort = oAuthOutputPort,
+        viewerWriter = viewerWriter,
     )
 
     fun stubTokenGeneration(uuid: String) {
@@ -49,7 +53,26 @@ class AuthServiceTest : DescribeSpec({
 
     beforeEach {
         reset(jwtUtils, jwtProperties, userWriter, userReader, adminProperties,
-            googleUserReader, googleUserWriter, oAuthOutputPort)
+            googleUserReader, googleUserWriter, oAuthOutputPort, viewerWriter)
+    }
+
+    describe("register") {
+        context("신규 유저 등록 시") {
+            it("User를 생성하고 ticket=0인 Viewer를 초기화한다") {
+                val newUuid = Uuid("new-uuid")
+                val newUser = User(id = 1L, uuid = newUuid)
+                val newViewer = Viewer(uuid = newUuid, ticket = 0, updatedTime = null)
+                whenever(userWriter.generateUser()).thenReturn(newUser)
+                whenever(viewerWriter.create(newUuid)).thenReturn(newViewer)
+                stubTokenGeneration(newUuid.value)
+
+                val result = authService.register()
+
+                verify(userWriter).generateUser()
+                verify(viewerWriter).create(newUuid)
+                result.accessToken shouldBe "access-token"
+            }
+        }
     }
 
     describe("loginWithGoogle") {


### PR DESCRIPTION
<!-- 이슈번호를 작성해주세요 -->
Closes #110

## 요약
- ViewerWriter.create(uuid) 추가 — ticket=0으로 초기 Viewer 생성
- AuthService.register()에서 User 생성 후 동일 트랜잭션 내 Viewer 자동 생성
- AuthServiceTest에 register() 테스트 추가

## 특이사항
<!-- 구현 시 고려한 사항이나 주의점이 있다면 작성해주세요 -->
- 