### PR TITLE
[#122]; fix: QA 리스트 - 구글 로그인 에러 로그 구체화 / deck API 구매 프로필 자동 제외.

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -133,6 +133,7 @@ jobs:
           WHITELIST: ${{ vars.WHITELIST }}
           CONTACT_LIMIT: ${{ vars.CONTACT_LIMIT }}
           CONTACT_LIMIT_WARNING: ${{ vars.CONTACT_LIMIT_WARNING }}
+          BANNED_WORDS: ${{ vars.BANNED_WORDS }}
           TICKET_COST: ${{ vars.TICKET_COST }}
           TICKET_PRICE_POLICY: ${{ vars.TICKET_PRICE_POLICY }}
           TICKET_PRICE_REGISTERED_POLICY: ${{ vars.TICKET_PRICE_REGISTERED_POLICY }}
@@ -187,6 +188,7 @@ jobs:
           echo "WHITELIST=$WHITELIST" >> .env
           echo "CONTACT_LIMIT=$CONTACT_LIMIT" >> .env
           echo "CONTACT_LIMIT_WARNING=$CONTACT_LIMIT_WARNING" >> .env
+          echo "BANNED_WORDS=$BANNED_WORDS" >> .env
           echo "TICKET_COST=$TICKET_COST" >> .env
           echo "TICKET_PRICE_POLICY=$TICKET_PRICE_POLICY" >> .env
           echo "TICKET_PRICE_REGISTERED_POLICY=$TICKET_PRICE_REGISTERED_POLICY" >> .env

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -133,6 +133,7 @@ jobs:
           WHITELIST: ${{ vars.WHITELIST }}
           CONTACT_LIMIT: ${{ vars.CONTACT_LIMIT }}
           CONTACT_LIMIT_WARNING: ${{ vars.CONTACT_LIMIT_WARNING }}
+          BANNED_WORDS: ${{ vars.BANNED_WORDS }}
 
           TICKET_COST: ${{ vars.TICKET_COST }}
           TICKET_PRICE_POLICY: ${{ vars.TICKET_PRICE_POLICY }}
@@ -187,6 +188,7 @@ jobs:
           echo "WHITELIST=$WHITELIST" >> .env
           echo "CONTACT_LIMIT=$CONTACT_LIMIT" >> .env
           echo "CONTACT_LIMIT_WARNING=$CONTACT_LIMIT_WARNING" >> .env
+          echo "BANNED_WORDS=$BANNED_WORDS" >> .env
           
           echo "TICKET_COST=$TICKET_COST" >> .env
           echo "TICKET_PRICE_POLICY=$TICKET_PRICE_POLICY" >> .env

--- a/app/src/main/kotlin/com/yourssu/signal/domain/profile/business/ProfileService.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/domain/profile/business/ProfileService.kt
@@ -74,7 +74,11 @@ class ProfileService(
         val myProfile = if (profileReader.existsByUuid(Uuid(command.uuid)))
             profileReader.getByUuid(Uuid(command.uuid))
         else null
-        val orderedIds = profilePriorityManager.buildDeck(myProfile?.id, Gender.of(command.gender))
+        val myPurchasedProfileIds = if (viewerReader.existsByUuid(Uuid(command.uuid))) {
+            val viewer = viewerReader.get(Uuid(command.uuid))
+            purchasedProfileReader.findProfileIdsByViewerId(viewer.id!!)
+        } else emptySet()
+        val orderedIds = profilePriorityManager.buildDeck(myProfile?.id, Gender.of(command.gender), myPurchasedProfileIds)
         return DeckResponse.from(profileReader.getOrderedByIds(orderedIds), myProfile)
     }
 

--- a/app/src/main/kotlin/com/yourssu/signal/domain/profile/implement/ProfilePriorityManager.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/domain/profile/implement/ProfilePriorityManager.kt
@@ -29,11 +29,11 @@ class ProfilePriorityManager(
         return profileReader.getById(candidateProfileId[profileIndex])
     }
 
-    fun buildDeck(myProfileId: Long?, gender: Gender): List<Long> {
+    fun buildDeck(myProfileId: Long?, gender: Gender, myPurchasedProfileIds: Set<Long> = emptySet()): List<Long> {
         val profileIdsByGender = profileReader.findIdsByGender(gender).toSet()
         val purchasedProfileIds = purchasedProfileReader.findProfileIdsOrderByPurchasedAsc().toSet()
         val blacklistProfileIds = blacklistReader.getAllBlacklistIds()
-        val excludeIds = blacklistProfileIds + setOfNotNull(myProfileId)
+        val excludeIds = blacklistProfileIds + setOfNotNull(myProfileId) + myPurchasedProfileIds
         val unpurchasedIds = profileIdsByGender
             .filter { it !in purchasedProfileIds && it !in excludeIds }
             .shuffled()

--- a/app/src/main/kotlin/com/yourssu/signal/domain/profile/implement/PurchasedProfileReader.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/domain/profile/implement/PurchasedProfileReader.kt
@@ -11,6 +11,10 @@ class PurchasedProfileReader(
         return purchasedProfileRepository.findByViewerId(viewerId)
     }
 
+    fun findProfileIdsByViewerId(viewerId: Long): Set<Long> {
+        return purchasedProfileRepository.findByViewerId(viewerId).map { it.profileId }.toSet()
+    }
+
     fun findProfileIdsOrderByPurchasedAsc(): List<Long> {
         return purchasedProfileRepository.findProfileIdsOrderByPurchasedAsc()
     }

--- a/app/src/main/kotlin/com/yourssu/signal/infrastructure/google/GoogleClient.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/infrastructure/google/GoogleClient.kt
@@ -3,6 +3,7 @@ package com.yourssu.signal.infrastructure.google
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.yourssu.signal.config.properties.GoogleOAuthConfigurationProperties
 import com.yourssu.signal.domain.auth.implement.OAuthOutputPort
+import io.github.oshai.kotlinlogging.KotlinLogging
 import okhttp3.FormBody
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -10,6 +11,8 @@ import org.springframework.stereotype.Component
 import java.io.IOException
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
+
+private val logger = KotlinLogging.logger {}
 
 @Component
 class GoogleClient(
@@ -40,10 +43,16 @@ class GoogleClient(
                     val tokenResponse = objectMapper.readTree(responseBody)
                     tokenResponse.get("id_token")?.asText()
                 } else {
+                    val errorBody = response.body.string()
+                    val errorJson = runCatching { objectMapper.readTree(errorBody) }.getOrNull()
+                    val error = errorJson?.get("error")?.asText() ?: "unknown"
+                    val description = errorJson?.get("error_description")?.asText() ?: errorBody
+                    logger.error { "Google OAuth token exchange failed: status=${response.code} error=$error description=$description" }
                     null
                 }
             }
-        } catch (_: IOException) {
+        } catch (e: IOException) {
+            logger.error { "Google OAuth token exchange IOException: ${e.message}" }
             null
         }
     }

--- a/app/src/test/kotlin/com/yourssu/signal/domain/profile/business/ProfileServiceTest.kt
+++ b/app/src/test/kotlin/com/yourssu/signal/domain/profile/business/ProfileServiceTest.kt
@@ -569,6 +569,32 @@ class ProfileServiceTest : DescribeSpec({
                     result.profiles shouldBe emptyList()
                 }
             }
+
+            context("이미 구매한 프로필이 있는 유저가 덱을 요청하면") {
+                it("구매한 프로필을 제외하고 buildDeck을 호출한다") {
+                    val command = DeckCommand(uuid = "buyer-uuid", gender = "FEMALE")
+                    val myProfile = createTestProfile(id = 1L, uuid = "buyer-uuid")
+                    val viewer = createTestViewer("buyer-uuid")
+                    val deckProfiles = listOf(
+                        createTestProfile(id = 3L, uuid = "uuid-3", nickname = "프로필3"),
+                    )
+
+                    whenever(profileReader.existsByUuid(Uuid("buyer-uuid"))).thenReturn(true)
+                    whenever(profileReader.getByUuid(Uuid("buyer-uuid"))).thenReturn(myProfile)
+                    whenever(viewerReader.existsByUuid(Uuid("buyer-uuid"))).thenReturn(true)
+                    whenever(viewerReader.get(Uuid("buyer-uuid"))).thenReturn(viewer)
+                    whenever(purchasedProfileReader.findProfileIdsByViewerId(1L)).thenReturn(setOf(2L))
+                    whenever(profilePriorityManager.buildDeck(eq(1L), eq(Gender.FEMALE), eq(setOf(2L)))).thenReturn(listOf(3L))
+                    whenever(profileReader.getOrderedByIds(listOf(3L))).thenReturn(deckProfiles)
+
+                    val result = profileService.getDeck(command)
+
+                    result.profiles.size shouldBe 1
+                    result.profiles[0].nickname shouldBe "프로필3"
+                    verify(purchasedProfileReader).findProfileIdsByViewerId(1L)
+                    verify(profilePriorityManager).buildDeck(eq(1L), eq(Gender.FEMALE), eq(setOf(2L)))
+                }
+            }
         }
 
         context("금지어 검사") {

--- a/app/src/test/kotlin/com/yourssu/signal/domain/profile/implement/ProfilePriorityManagerTest.kt
+++ b/app/src/test/kotlin/com/yourssu/signal/domain/profile/implement/ProfilePriorityManagerTest.kt
@@ -106,5 +106,77 @@ class ProfilePriorityManagerTest : DescribeSpec({
                 deck shouldBe listOf(2L, 1L)
             }
         }
+
+        context("내가 구매한 프로필 ID가 전달되면") {
+            it("해당 프로필은 덱에 포함되지 않는다") {
+                whenever(profileReader.findIdsByGender(Gender.FEMALE)).thenReturn(listOf(1L, 2L, 3L, 4L))
+                whenever(purchasedProfileReader.findProfileIdsOrderByPurchasedAsc()).thenReturn(listOf(3L, 4L))
+                whenever(blacklistReader.getAllBlacklistIds()).thenReturn(emptySet())
+
+                val deck = manager.buildDeck(myProfileId = null, gender = Gender.FEMALE, myPurchasedProfileIds = setOf(3L))
+
+                deck shouldNotContain 3L
+                deck shouldContainAll listOf(1L, 2L, 4L)
+            }
+        }
+
+        context("내가 해당 성별의 모든 프로필을 구매했으면") {
+            it("빈 덱을 반환한다") {
+                whenever(profileReader.findIdsByGender(Gender.FEMALE)).thenReturn(listOf(1L, 2L))
+                whenever(purchasedProfileReader.findProfileIdsOrderByPurchasedAsc()).thenReturn(emptyList())
+                whenever(blacklistReader.getAllBlacklistIds()).thenReturn(emptySet())
+
+                val deck = manager.buildDeck(myProfileId = null, gender = Gender.FEMALE, myPurchasedProfileIds = setOf(1L, 2L))
+
+                deck shouldBe emptyList()
+            }
+        }
+
+        context("내가 프로필 1만 구매했고 프로필이 1, 2 있으면") {
+            it("프로필 2만 덱에 반환된다") {
+                whenever(profileReader.findIdsByGender(Gender.FEMALE)).thenReturn(listOf(1L, 2L))
+                whenever(purchasedProfileReader.findProfileIdsOrderByPurchasedAsc()).thenReturn(emptyList())
+                whenever(blacklistReader.getAllBlacklistIds()).thenReturn(emptySet())
+
+                val deck = manager.buildDeck(myProfileId = null, gender = Gender.FEMALE, myPurchasedProfileIds = setOf(1L))
+
+                deck shouldBe listOf(2L)
+            }
+        }
+
+        context("profiles/random과 동일하게 전역 구매순 정렬이 유지되면서 내 구매 프로필만 제외되면") {
+            it("미구매(전역) 프로필이 앞에, 전역 구매 프로필이 뒤에 오고 내가 구매한 프로필은 없다") {
+                // 전체 프로필: 1,2,3,4,5 / 전역 구매된 것: 4,5 / 내가 구매한 것: 3
+                whenever(profileReader.findIdsByGender(Gender.MALE)).thenReturn(listOf(1L, 2L, 3L, 4L, 5L))
+                whenever(purchasedProfileReader.findProfileIdsOrderByPurchasedAsc()).thenReturn(listOf(4L, 5L))
+                whenever(blacklistReader.getAllBlacklistIds()).thenReturn(emptySet())
+
+                val deck = manager.buildDeck(myProfileId = null, gender = Gender.MALE, myPurchasedProfileIds = setOf(3L))
+
+                // 3은 제외
+                deck shouldNotContain 3L
+                // 전역 미구매(1,2)가 전역 구매(4,5)보다 앞에
+                val globalPurchasedInDeck = setOf(4L, 5L)
+                val unpurchasedPart = deck.takeWhile { it !in globalPurchasedInDeck }
+                val purchasedPart = deck.dropWhile { it !in globalPurchasedInDeck }
+                unpurchasedPart.toSet() shouldBe setOf(1L, 2L)
+                purchasedPart shouldBe listOf(4L, 5L)
+            }
+        }
+
+        context("여자 프로필 100개가 있고 구매 이력이 없으면") {
+            it("중복 없이 정확히 100개를 반환한다") {
+                val allIds = (1L..100L).toList()
+                whenever(profileReader.findIdsByGender(Gender.FEMALE)).thenReturn(allIds)
+                whenever(purchasedProfileReader.findProfileIdsOrderByPurchasedAsc()).thenReturn(emptyList())
+                whenever(blacklistReader.getAllBlacklistIds()).thenReturn(emptySet())
+
+                val deck = manager.buildDeck(myProfileId = null, gender = Gender.FEMALE)
+
+                deck.size shouldBe 100
+                deck.toSet().size shouldBe 100  // 중복 없음
+                deck.toSet() shouldBe allIds.toSet()  // 전체 포함
+            }
+        }
     }
 })


### PR DESCRIPTION
<!-- 이슈번호를 작성해주세요 -->
Closes #122

## 요약
- GoogleClient 실패 시 error, error_description을 로그에 기록하도록 개선
- ProfilePriorityManager.buildDeck()에 구매 프로필 제외 로직 추가
- CI 워크플로우 업데이트

## 특이사항
<!-- 구현 시 고려한 사항이나 주의점이 있다면 작성해주세요 -->
- 