### PR TITLE
[#123]; feat: 한 번이라도 구매된 고유 프로필 수를 조회할 수 있다.

### DIFF
--- a/app/src/main/kotlin/com/yourssu/signal/api/ProfileController.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/api/ProfileController.kt
@@ -210,4 +210,14 @@ class ProfileController(
         val response = profileService.getConnectionsCount()
         return ResponseEntity.ok(Response(result = response))
     }
+
+    @Operation(
+        summary = "구매된 고유 프로필 수 조회",
+        description = "한 번이라도 구매된 고유 프로필의 수를 조회합니다. 벌써 00명이 시그널로 연결됐어요 기능에 사용"
+    )
+    @GetMapping("/purchased/count")
+    fun countDistinctPurchasedProfiles(): ResponseEntity<Response<ProfilesCountResponse>> {
+        val response = profileService.countDistinctPurchasedProfiles()
+        return ResponseEntity.ok(Response(result = response))
+    }
 }

--- a/app/src/main/kotlin/com/yourssu/signal/domain/profile/business/ProfileService.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/domain/profile/business/ProfileService.kt
@@ -152,6 +152,10 @@ class ProfileService(
         return ConnectionsCountResponse.of(maleCount, femaleCount)
     }
 
+    fun countDistinctPurchasedProfiles(): ProfilesCountResponse {
+        return ProfilesCountResponse.of(purchasedProfileReader.countDistinctPurchasedProfiles())
+    }
+
     private fun validateBannedWords(nickname: String, introSentences: List<String>) {
         val bannedWords = policy.bannedWords.toSet()
         ProfileValidator.validateNicknameBannedWord(nickname, bannedWords)

--- a/app/src/main/kotlin/com/yourssu/signal/domain/profile/implement/PurchasedProfileReader.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/domain/profile/implement/PurchasedProfileReader.kt
@@ -23,4 +23,8 @@ class PurchasedProfileReader(
     fun countByGender(gender: Gender): Int {
         return purchasedProfileRepository.countByGender(gender)
     }
+
+    fun countDistinctPurchasedProfiles(): Int {
+        return purchasedProfileRepository.countDistinctPurchasedProfiles()
+    }
 }

--- a/app/src/main/kotlin/com/yourssu/signal/domain/profile/implement/PurchasedProfileRepository.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/domain/profile/implement/PurchasedProfileRepository.kt
@@ -7,4 +7,5 @@ interface PurchasedProfileRepository {
     fun findProfileIdsOrderByPurchasedAsc(): List<Long>
     fun findProfileCountGroupByProfileId(gender: Gender): Map<Long, ProfileRanking>
     fun countByGender(gender: Gender): Int
+    fun countDistinctPurchasedProfiles(): Int
 }

--- a/app/src/main/kotlin/com/yourssu/signal/domain/profile/storage/PurchasedProfileRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/domain/profile/storage/PurchasedProfileRepositoryImpl.kt
@@ -96,6 +96,13 @@ class PurchasedProfileRepositoryImpl(
             .where(purchasedProfileEntity.profileId.`in`(profileIdsWithGender))
             .fetchOne() ?: 0
     }
+
+    override fun countDistinctPurchasedProfiles(): Int {
+        return jpaQueryFactory
+            .select(purchasedProfileEntity.profileId.countDistinct().castToNum(Int::class.java))
+            .from(purchasedProfileEntity)
+            .fetchOne() ?: 0
+    }
 }
 
 interface PurchasedProfileJpaRepository : JpaRepository<PurchasedProfileEntity, Long> {

--- a/app/src/test/kotlin/com/yourssu/signal/domain/profile/business/ProfileServiceTest.kt
+++ b/app/src/test/kotlin/com/yourssu/signal/domain/profile/business/ProfileServiceTest.kt
@@ -986,6 +986,37 @@ class ProfileServiceTest : DescribeSpec({
             }
         }
 
+        describe("countDistinctPurchasedProfiles 메서드를 호출할 때") {
+
+            context("구매된 고유 프로필이 있으면") {
+                it("고유 프로필 수를 반환한다") {
+                    // given
+                    whenever(purchasedProfileReader.countDistinctPurchasedProfiles()).thenReturn(4)
+
+                    // when
+                    val result = profileService.countDistinctPurchasedProfiles()
+
+                    // then
+                    result.count shouldBe 4
+                    verify(purchasedProfileReader).countDistinctPurchasedProfiles()
+                }
+            }
+
+            context("구매된 프로필이 없으면") {
+                it("0을 반환한다") {
+                    // given
+                    whenever(purchasedProfileReader.countDistinctPurchasedProfiles()).thenReturn(0)
+
+                    // when
+                    val result = profileService.countDistinctPurchasedProfiles()
+
+                    // then
+                    result.count shouldBe 0
+                    verify(purchasedProfileReader).countDistinctPurchasedProfiles()
+                }
+            }
+        }
+
         describe("getConnectionsCount 메서드를 호출할 때") {
 
             context("남성/여성 구매 기록이 있으면") {

--- a/app/src/test/kotlin/com/yourssu/signal/domain/profile/storage/PurchasedProfileRepositoryImplTest.kt
+++ b/app/src/test/kotlin/com/yourssu/signal/domain/profile/storage/PurchasedProfileRepositoryImplTest.kt
@@ -117,6 +117,45 @@ class PurchasedProfileRepositoryImplIntegrationTest {
         assertEquals(0, femaleCount)
     }
 
+    @Test
+    fun `한 번이라도 구매된 고유 프로필 수를 반환한다`() {
+        // given - 2개 프로필 각 1번씩 구매
+        val profile1 = createAndSaveProfile(gender = Gender.MALE, uuid = "uuid-1")
+        val profile2 = createAndSaveProfile(gender = Gender.FEMALE, uuid = "uuid-2")
+        purchasedProfileJpaRepository.save(PurchasedProfileEntity(profileId = profile1.id!!, viewerId = 1L))
+        purchasedProfileJpaRepository.save(PurchasedProfileEntity(profileId = profile2.id!!, viewerId = 2L))
+
+        // when
+        val result = purchasedProfileRepository.countDistinctPurchasedProfiles()
+
+        // then
+        assertEquals(2, result)
+    }
+
+    @Test
+    fun `같은 프로필을 여러 명이 구매해도 고유 프로필 수는 1이다`() {
+        // given - 1개 프로필을 3명이 구매
+        val profile = createAndSaveProfile(gender = Gender.MALE, uuid = "uuid-1")
+        purchasedProfileJpaRepository.save(PurchasedProfileEntity(profileId = profile.id!!, viewerId = 1L))
+        purchasedProfileJpaRepository.save(PurchasedProfileEntity(profileId = profile.id!!, viewerId = 2L))
+        purchasedProfileJpaRepository.save(PurchasedProfileEntity(profileId = profile.id!!, viewerId = 3L))
+
+        // when
+        val result = purchasedProfileRepository.countDistinctPurchasedProfiles()
+
+        // then
+        assertEquals(1, result)
+    }
+
+    @Test
+    fun `구매 기록이 없으면 countDistinctPurchasedProfiles는 0을 반환한다`() {
+        // when
+        val result = purchasedProfileRepository.countDistinctPurchasedProfiles()
+
+        // then
+        assertEquals(0, result)
+    }
+
     private fun createAndSaveProfile(
         gender: Gender,
         uuid: String,


### PR DESCRIPTION
<!-- 이슈번호를 작성해주세요 -->
Closes #123

## 요약
- GET /api/profiles/purchased/count 엔드포인트 추가 (인증 불필요)
- QueryDSL countDistinct()로 고유 구매 프로필 수 집계
- ProfilesCountResponse 재사용하여 { count: N } 형식으로 반환

## 특이사항
<!-- 구현 시 고려한 사항이나 주의점이 있다면 작성해주세요 -->
- 