### PR TITLE
[#123]; feat: 한 번이라도 구매된 고유 프로필 수를 조회할 수 있다.

### DIFF
--- a/.github/workflows/deploy-only.yml
+++ b/.github/workflows/deploy-only.yml
@@ -136,7 +136,7 @@ jobs:
           
           # Deploy environment file and docker script to host machine
           scp -i yourssu.pem .env ubuntu@$HOST_URL:/home/ubuntu/$PROJECT_NAME-api/
-          scp -i yourssu.pem script/docker-deploy.sh ubuntu@$HOST_URL:/home/ubuntu/$PROJECT_NAME-api/
+          scp -i yourssu.pem observer/script/docker-deploy.sh ubuntu@$HOST_URL:/home/ubuntu/$PROJECT_NAME-api/
           
           # Make the script executable
           ssh -i yourssu.pem ubuntu@$HOST_URL "chmod +x /home/ubuntu/$PROJECT_NAME-api/docker-deploy.sh"

--- a/app/src/main/kotlin/com/yourssu/signal/domain/profile/implement/CompatibilityLabel.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/domain/profile/implement/CompatibilityLabel.kt
@@ -1,7 +1,9 @@
 package com.yourssu.signal.domain.profile.implement
 
 enum class CompatibilityLabel(val message: String?) {
-    PERFECT_MATCH("찰떡 궁합 PICK 내 운명의 상대... 이 사람일지도?"),
+    PERFECT_MATCH("이 사람 운명일지도..? 시그널이 추천하는 환상의 궁합"),
+    MBTI_AGE_MATCH("이 사람 운명일지도..? 생각의 주파수가 같은 사이"),
+    ANIMAL_AGE_MATCH("이 사람 운명일지도..? 외적인 주파수가 맞는 사이"),
     MBTI_MATCH(null),
     ANIMAL_MATCH(null),
     AGE_MATCH(null),

--- a/app/src/main/kotlin/com/yourssu/signal/domain/profile/implement/CompatibilityMatcher.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/domain/profile/implement/CompatibilityMatcher.kt
@@ -8,6 +8,8 @@ object CompatibilityMatcher {
         val animalMatch = AnimalCompatibilityTable.isCompatible(myProfile, targetProfile)
         return when {
             ageMatch && mbtiMatch && animalMatch -> CompatibilityLabel.PERFECT_MATCH
+            ageMatch && mbtiMatch -> CompatibilityLabel.MBTI_AGE_MATCH
+            ageMatch && animalMatch -> CompatibilityLabel.ANIMAL_AGE_MATCH
             mbtiMatch -> CompatibilityLabel.MBTI_MATCH
             animalMatch -> CompatibilityLabel.ANIMAL_MATCH
             ageMatch -> CompatibilityLabel.AGE_MATCH

--- a/app/src/main/kotlin/com/yourssu/signal/domain/viewer/implement/TicketPricePolicy.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/domain/viewer/implement/TicketPricePolicy.kt
@@ -49,7 +49,9 @@ class TicketPricePolicy(
         return ticketPackages.findByPrice(price, isFirstPurchasedTicket(uuid))
     }
 
-    private fun isFirstPurchasedTicket(uuid: Uuid): Boolean = false
+    private fun isFirstPurchasedTicket(uuid: Uuid): Boolean {
+        return profileReader.existsByUuid(uuid) && !viewerReader.existsByUuid(uuid)
+    }
 
     fun getTicketPackages(): TicketPackages {
         return ticketPackages

--- a/app/src/test/kotlin/com/yourssu/signal/domain/profile/implement/CompatibilityMatcherTest.kt
+++ b/app/src/test/kotlin/com/yourssu/signal/domain/profile/implement/CompatibilityMatcherTest.kt
@@ -5,6 +5,8 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 
 private val PERFECT = CompatibilityLabel.PERFECT_MATCH
+private val MBTI_AGE = CompatibilityLabel.MBTI_AGE_MATCH
+private val ANIMAL_AGE = CompatibilityLabel.ANIMAL_AGE_MATCH
 private val MBTI = CompatibilityLabel.MBTI_MATCH
 private val ANIMAL = CompatibilityLabel.ANIMAL_MATCH
 private val AGE = CompatibilityLabel.AGE_MATCH
@@ -87,20 +89,38 @@ class CompatibilityMatcherTest : DescribeSpec({
             }
         }
 
-        context("MBTI만 맞고 동물상은 안 맞으면") {
-            it("MBTI_MATCH 반환") {
+        context("MBTI와 나이가 맞고 동물상이 안 맞으면") {
+            it("MBTI_AGE_MATCH 반환") {
                 // FOX(여) → 매칭 상대: DINOSAUR, DEER / DOG은 해당 없음
                 val f = female("INFP", Animal.FOX, 2001)
                 val m = male("ENFJ", Animal.DOG, 2000)
+                CompatibilityMatcher.match(f, m) shouldBe MBTI_AGE
+            }
+        }
+
+        context("동물상과 나이가 맞고 MBTI가 안 맞으면") {
+            it("ANIMAL_AGE_MATCH 반환") {
+                // CAT(여) → 매칭 상대: DOG, BEAR / ENFP → 매칭 상대: INFJ, INTJ (ENFJ 해당 없음)
+                val f = female("ENFP", Animal.CAT, 2001)
+                val m = male("ENFJ", Animal.DOG, 2000)
+                CompatibilityMatcher.match(f, m) shouldBe ANIMAL_AGE
+            }
+        }
+
+        context("MBTI만 맞고 동물상·나이 모두 안 맞으면") {
+            it("MBTI_MATCH 반환") {
+                // FOX(여) → 매칭 상대: DINOSAUR, DEER / DOG은 해당 없음. 남자 연하 → 나이 불충족
+                val f = female("INFP", Animal.FOX, 2001)
+                val m = male("ENFJ", Animal.DOG, 2003)
                 CompatibilityMatcher.match(f, m) shouldBe MBTI
             }
         }
 
-        context("동물상만 맞고 MBTI는 안 맞으면") {
+        context("동물상만 맞고 MBTI·나이 모두 안 맞으면") {
             it("ANIMAL_MATCH 반환") {
-                // CAT(여) → 매칭 상대: DOG, BEAR / ENFP → 매칭 상대: INFJ, INTJ (ENFJ 해당 없음)
+                // CAT(여) → 매칭 상대: DOG, BEAR / ENFP → INFJ, INTJ (ENFJ 해당 없음). 남자 연하 → 나이 불충족
                 val f = female("ENFP", Animal.CAT, 2001)
-                val m = male("ENFJ", Animal.DOG, 2000)
+                val m = male("ENFJ", Animal.DOG, 2003)
                 CompatibilityMatcher.match(f, m) shouldBe ANIMAL
             }
         }


### PR DESCRIPTION
<!-- 이슈번호를 작성해주세요 -->
Closes #123

## 요약
- 한 번이라도 구매된 고유 프로필 수 조회 API 추가 (PurchasedProfileReader, PurchasedProfileRepositoryImpl)
- 궁합 멘트 케이스 보강 (CompatibilityLabel, CompatibilityMatcher)
- 첫 구매 할인 로직 활성화 및 deploy-only.yml SCP 경로 수정

## 특이사항
<!-- 구현 시 고려한 사항이나 주의점이 있다면 작성해주세요 -->
- 