### PR TITLE
[#131]; fix: observer_run.sh nohup redirect 버그로 observer.out에 로그가 기록되지 않는다.

### DIFF
--- a/observer/observer_run.sh
+++ b/observer/observer_run.sh
@@ -1,3 +1,3 @@
 cd /home/ubuntu/signal-api
 sudo ps -ef | grep '[p]ython.*observer\.py' | awk '{print $2}' | xargs sudo kill -9
-nohup env PYTHONPATH=$(pwd)/script python3 script/observer.py > observer.out > /dev/null 2>&1 &
+nohup env PYTHONPATH=$(pwd)/script python3 script/observer.py > observer.out 2>&1 &


### PR DESCRIPTION
<!-- 이슈번호를 작성해주세요 -->
Closes #131

## 요약
- observer_run.sh의 nohup 이중 redirect 버그 수정 (> observer.out > /dev/null → > observer.out)
- 수정 후 observer 스크립트의 stdout/stderr가 observer.out에 정상 기록됨

## 특이사항
<!-- 구현 시 고려한 사항이나 주의점이 있다면 작성해주세요 -->
- 