### PR TITLE
fix: observer Slack 알림 누락 개선 및 입금 잔액 표시 추가

### DIFF
--- a/app/src/main/kotlin/com/yourssu/signal/infrastructure/logging/Notification.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/infrastructure/logging/Notification.kt
@@ -39,7 +39,7 @@ object Notification {
     }
 
     fun notifyIssueTicketByBankDepositSms(message: SMSMessage) {
-        logger.info { "IssueTicketByBankDepositSms&${message.name} ${message.depositAmount}" }
+        logger.info { "IssueTicketByBankDepositSms&${message.name} ${message.depositAmount} ${message.remainingAmount ?: 0}" }
     }
 
     fun notifyIssueFailedTicketByDepositAmount(message: SMSMessage) {

--- a/app/src/main/resources/nginx/signal
+++ b/app/src/main/resources/nginx/signal
@@ -38,6 +38,17 @@ server {
         access_log /var/log/nginx/signal-api.yourssu.com.access.log;
         error_log /var/log/nginx/signal-api.yourssu.com.error.log;
 
+        # Slack slash command 프록시 (admin.py, port 3005)
+        location /slack/ {
+                proxy_pass http://localhost:3005;
+                proxy_redirect off;
+                proxy_http_version 1.1;
+                proxy_set_header Host $http_host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
         # 메인 프록시 설정
         location / {
                 # 프록시 대상 서버

--- a/app/src/main/resources/nginx/signal-dev
+++ b/app/src/main/resources/nginx/signal-dev
@@ -38,6 +38,17 @@ server {
         access_log /var/log/nginx/signal-dev-api.yourssu.com.access.log;
         error_log /var/log/nginx/signal-dev-api.yourssu.com.error.log;
 
+        # Slack slash command 프록시 (admin.py, port 3005)
+        location /slack/ {
+                proxy_pass http://localhost:3005;
+                proxy_redirect off;
+                proxy_http_version 1.1;
+                proxy_set_header Host $http_host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
         # 메인 프록시 설정
         location / {
                 # 프록시 대상 서버

--- a/observer/script/observer.py
+++ b/observer/script/observer.py
@@ -37,8 +37,11 @@ class SlackNotifier:
             'Authorization': f'Bearer {self.config.slack_token}',
             'Content-Type': 'application/json'
         }
-        response = requests.post(self.config.slack_webhook_url, json=payload, headers=headers)
-        print(response.text)
+        try:
+            response = requests.post(self.config.slack_webhook_url, json=payload, headers=headers, timeout=10)
+            print(response.text)
+        except Exception as e:
+            print(f"Slack 알림 전송 실패: {e}")
         
     def send_notification(self, message: str):
         self._send_notification(self.config.slack_channel, message)

--- a/observer/script/signal_handler.py
+++ b/observer/script/signal_handler.py
@@ -193,11 +193,13 @@ class SignalHandler:
 
     def create_issue_ticket_message(self, line):
         """입금 확인 완료 메시지"""
-        name, deposit_amount = line[line.find('&') + 1:].split(' ')
+        parts = line[line.find('&') + 1:].strip().rsplit(' ', 2)
+        name, deposit_amount, remaining_amount = parts[0], parts[1], parts[2]
         now_kst = self._get_kst_now()
         message = f"""💰 *입금 확인 완료* 💰
         -  💌 *받는 분 통장 표시*: {name}
         -  💰 *금액*: {deposit_amount.strip()}원
+        -  🏦 *잔액*: {remaining_amount.strip()}원
         -  ⏰ *시간*: {now_kst.strftime('%Y-%m-%d %H:%M:%S')} KST
         """
         self.notifier.send_notification(message)


### PR DESCRIPTION
## Summary

- `observer.py`: `requests.post()` timeout=10 추가 + 예외 처리 — Slack API 무응답 시 watchdog 스레드 블로킹 방지 (2026-05-13 40분 알림 누락 근본 원인)
- `signal_handler.py`: 입금 확인 Slack 메시지에 🏦 잔액 항목 추가, `rsplit`으로 파싱 안정화
- `Notification.kt`: `IssueTicketByBankDepositSms` 로그에 `remainingAmount` 포함 (`signal_handler.py`와 동시 배포 — 같은 이미지라 자동)
- `nginx/signal`, `nginx/signal-dev`: `/slack/` location 블록 추가 (admin.py port 3005 프록시)

closes #135

## Test plan

- [ ] 입금 SMS 처리 후 Slack 알림에 🏦 잔액 항목 표시 확인
- [ ] Slack API 타임아웃 시 observer가 계속 동작하는지 확인 (hang 없음)
- [ ] nginx `/slack/` 프록시 동작 확인 (`nginx -t && nginx -s reload`)