### PR TITLE
[#134]; fix: Docker 캐시 키에 observer 스크립트 전체 포함.

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -80,9 +80,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ hashFiles('observer/script/requirements.txt', 'app/Dockerfile') }}-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-${{ hashFiles('observer/script/**', 'app/Dockerfile') }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-buildx-${{ hashFiles('observer/script/requirements.txt', 'app/Dockerfile') }}-
+            ${{ runner.os }}-buildx-${{ hashFiles('observer/script/**', 'app/Dockerfile') }}-
             ${{ runner.os }}-buildx-
 
       - name: Build, tag, and push image to Amazon ECR

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -80,9 +80,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ hashFiles('observer/script/requirements.txt', 'app/Dockerfile') }}-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-${{ hashFiles('observer/script/**', 'app/Dockerfile') }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-buildx-${{ hashFiles('observer/script/requirements.txt', 'app/Dockerfile') }}-
+            ${{ runner.os }}-buildx-${{ hashFiles('observer/script/**', 'app/Dockerfile') }}-
             ${{ runner.os }}-buildx-
 
       - name: Build, tag, and push image to Amazon ECR


### PR DESCRIPTION
<!-- 이슈번호를 작성해주세요 -->
Closes #134

## 요약
- dev.yml, prod.yml의 Docker 레이어 캐시 키를 `observer/script/**`로 확장
- 기존 `requirements.txt`만 감시하던 캐시 키가 Python 스크립트 변경을 감지 못해 구버전 컨테이너가 배포되는 버그 수정

## 특이사항
<!-- 구현 시 고려한 사항이나 주의점이 있다면 작성해주세요 -->
- 