### PR TITLE
[#138]; fix: observer watchdog 스레드 종료로 Slack 알림이 중단된다.

### DIFF
--- a/app/src/main/kotlin/com/yourssu/signal/infrastructure/logging/Notification.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/infrastructure/logging/Notification.kt
@@ -14,7 +14,8 @@ object Notification {
                     "&${profile.department}" +
                     "&${profile.contact}" +
                     "&${profile.nickname}" +
-                    "&${profile.introSentences.joinToString(",")}"
+                    "&${profile.introSentences.joinToString(",")}" +
+                    "&${profile.gender}"
         }
     }
 

--- a/observer/script/observer.py
+++ b/observer/script/observer.py
@@ -37,8 +37,16 @@ class SlackNotifier:
             'Authorization': f'Bearer {self.config.slack_token}',
             'Content-Type': 'application/json'
         }
-        response = requests.post(self.config.slack_webhook_url, json=payload, headers=headers)
-        print(response.text)
+        try:
+            response = requests.post(
+                self.config.slack_webhook_url,
+                json=payload,
+                headers=headers,
+                timeout=10
+            )
+            print(response.text)
+        except requests.RequestException as e:
+            print(f"Slack notification failed: {e}")
         
     def send_notification(self, message: str):
         self._send_notification(self.config.slack_channel, message)
@@ -134,9 +142,18 @@ if __name__ == "__main__":
     start_message = f"Observer started: {TimeUtils.get_kst_now()}"
     print(start_message)
     notifier.send_log_notification(start_message)
+    HEALTH_CHECK_INTERVAL = 30
+    tick = 0
     try:
         while True:
             time.sleep(1)
+            tick += 1
+            if tick >= HEALTH_CHECK_INTERVAL:
+                tick = 0
+                if not observer.is_alive():
+                    msg = f"🚨 Observer watchdog thread died: {TimeUtils.get_kst_now()}\n재시작 필요: docker restart signal-backend-container"
+                    print(msg)
+                    notifier.send_log_notification(msg)
     except KeyboardInterrupt:
         observer.stop()
     observer.join()

--- a/observer/script/signal_handler.py
+++ b/observer/script/signal_handler.py
@@ -51,10 +51,12 @@ class SignalHandler:
 
     def create_profile_message(self, line):
         """프로필 등록 완료 메시지 및 정책 위반 검사"""
-        id, department, contact, nickname, introSentences = line[line.find('&') + 1:].split('&')
+        id, department, contact, nickname, introSentences, gender = line[line.find('&') + 1:].split('&')
+        gender_display = '여성' if gender.strip() == 'FEMALE' else '남성'
         message = f"""🩷 *프로필 등록 완료* 🩷
     -  💖 *식별 번호*: {id}
     -  🏢 *학과*: {department}
+    -  🚻 *성별*: {gender_display}
     -  📞 *연락처*: https://www.instagram.com/{contact.replace('@', '')}
     -  👤 *닉네임*: {nickname}
     -  📝 *자기소개*: {introSentences}


### PR DESCRIPTION
<!-- 이슈번호를 작성해주세요 -->
Closes #138
Closes #140

## 요약
- SlackNotifier._send_notification에 timeout=10 추가 및 RequestException 처리 — Slack API hang 시 10초 내 watchdog 스레드 block 방지
- 메인 루프에서 30초마다 observer.is_alive() 체크, 스레드 사망 감지 시 Slack 로그 채널에 재시작 요청 알림
- 프로필 등록 Slack 알림에 성별(여성/남성) 항목 추가 (Notification.kt 로그 포맷 + observer 파싱 동시 변경)

## 특이사항
<!-- 구현 시 고려한 사항이나 주의점이 있다면 작성해주세요 -->
- 