### PR TITLE
fix: observer 구버전 배포 방지 및 gender 필드 롤백

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -75,16 +75,6 @@ jobs:
         run: |
           ./gradlew clean build --build-cache --parallel --daemon
 
-      # Docker 베이스 이미지 캐시
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ hashFiles('observer/script/**', 'app/Dockerfile') }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-${{ hashFiles('observer/script/**', 'app/Dockerfile') }}-
-            ${{ runner.os }}-buildx-
-
       - name: Build, tag, and push image to Amazon ECR
         env:
           ECR_REGISTRY: public.ecr.aws/${{ vars.ECR_PUBLIC_REGISTRY_ID }}
@@ -93,27 +83,21 @@ jobs:
           echo "ECR_REGISTRY: $ECR_REGISTRY"
           echo "ECR_REPOSITORY: yourssu/${{ vars.PROJECT_NAME }}"
           echo "Full image path: $ECR_REGISTRY/yourssu/${{ vars.PROJECT_NAME }}:latest"
-          
+
           # Create and use a new builder instance
           docker buildx create --use --name arm-builder
-          
-          # Build multi-platform image (ARM64 + AMD64) and push with enhanced cache
+
+          # Build multi-platform image (ARM64 + AMD64) and push
           docker buildx build \
             -f app/Dockerfile \
             --platform linux/arm64,linux/amd64 \
             --push \
             --provenance=false \
             --cache-from type=gha \
-            --cache-from type=local,src=/tmp/.buildx-cache \
             --cache-to type=gha,mode=max \
-            --cache-to type=local,dest=/tmp/.buildx-cache-new,mode=max \
             -t $ECR_REGISTRY/yourssu/${{ vars.PROJECT_NAME }}:$IMAGE_TAG \
             -t $ECR_REGISTRY/yourssu/${{ vars.PROJECT_NAME }}:latest \
             .
-          
-          # 캐시 교체
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
       - name: Deploy to EC2
         env:

--- a/app/src/main/kotlin/com/yourssu/signal/infrastructure/logging/Notification.kt
+++ b/app/src/main/kotlin/com/yourssu/signal/infrastructure/logging/Notification.kt
@@ -14,8 +14,7 @@ object Notification {
                     "&${profile.department}" +
                     "&${profile.contact}" +
                     "&${profile.nickname}" +
-                    "&${profile.introSentences.joinToString(",")}" +
-                    "&${profile.gender}"
+                    "&${profile.introSentences.joinToString(",")}"
         }
     }
 

--- a/observer/script/observer.py
+++ b/observer/script/observer.py
@@ -88,7 +88,7 @@ def process_line_with_handlers(line, handlers):
 def check(file_path):
     global last_checked_line
 
-    with open(file_path, 'r', encoding='utf-8') as file:
+    with open(file_path, 'r', encoding='utf-8', errors='ignore') as file:
         lines = file.readlines()
         if file_path not in last_checked_line:
             last_checked_line[file_path] = len(lines)

--- a/observer/script/signal_handler.py
+++ b/observer/script/signal_handler.py
@@ -51,12 +51,10 @@ class SignalHandler:
 
     def create_profile_message(self, line):
         """프로필 등록 완료 메시지 및 정책 위반 검사"""
-        id, department, contact, nickname, introSentences, gender = line[line.find('&') + 1:].split('&')
-        gender_display = '여성' if gender.strip() == 'FEMALE' else '남성'
+        id, department, contact, nickname, introSentences = line[line.find('&') + 1:].split('&')
         message = f"""🩷 *프로필 등록 완료* 🩷
     -  💖 *식별 번호*: {id}
     -  🏢 *학과*: {department}
-    -  🚻 *성별*: {gender_display}
     -  📞 *연락처*: https://www.instagram.com/{contact.replace('@', '')}
     -  👤 *닉네임*: {nickname}
     -  📝 *자기소개*: {introSentences}


### PR DESCRIPTION
## Summary

- **prod.yml**: 로컬 Docker 레이어 캐시(`type=local`) 제거 — `observer/script/` 변경사항이 캐시 히트로 구버전 배포되던 문제 근본 해결
- **Notification.kt**: 프로필 로그에서 `&${profile.gender}` 제거 (5필드로 복원)
- **signal_handler.py**: 6필드 → 5필드 파싱 복원, Slack 메시지 성별 라인 제거
- **observer.py**: 한글 로그 파일 읽기 중 `UnicodeDecodeError` 방지 (`errors='ignore'` 추가)

## Background

이미지 빌드 시각(05-14 02:53 KST)이 gender 커밋(`bbd3510`, 05-14 15:20 KST) 이전이라, 이미지 내 observer는 5필드 파싱 상태였음. 로컬 코드만 6필드로 업데이트되어 파싱 불일치 → `UnicodeDecodeError` 발생.

## Test plan

- [ ] prod.yml으로 배포 후 observer가 최신 코드로 실행되는지 Slack `#signal-log` 확인
- [ ] 프로필 등록 시 Slack 알림에 5개 필드(식별번호, 학과, 연락처, 닉네임, 자기소개)만 표시되는지 확인
- [ ] observer 로그에 UnicodeDecodeError 없는지 확인