### PR TITLE
fix: observer 초기 스캔 UnicodeDecodeError로 SERVER RESTARTED 미전송 수정

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -75,6 +75,16 @@ jobs:
         run: |
           ./gradlew clean build --build-cache --parallel --daemon
 
+      # Docker 베이스 이미지 캐시
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ hashFiles('observer/script/**', 'app/Dockerfile') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-${{ hashFiles('observer/script/**', 'app/Dockerfile') }}-
+            ${{ runner.os }}-buildx-
+
       - name: Build, tag, and push image to Amazon ECR
         env:
           ECR_REGISTRY: public.ecr.aws/${{ vars.ECR_PUBLIC_REGISTRY_ID }}
@@ -83,21 +93,27 @@ jobs:
           echo "ECR_REGISTRY: $ECR_REGISTRY"
           echo "ECR_REPOSITORY: yourssu/${{ vars.PROJECT_NAME }}"
           echo "Full image path: $ECR_REGISTRY/yourssu/${{ vars.PROJECT_NAME }}:latest"
-
+          
           # Create and use a new builder instance
           docker buildx create --use --name arm-builder
-
-          # Build multi-platform image (ARM64 + AMD64) and push
+          
+          # Build multi-platform image (ARM64 + AMD64) and push with enhanced cache
           docker buildx build \
             -f app/Dockerfile \
             --platform linux/arm64,linux/amd64 \
             --push \
             --provenance=false \
             --cache-from type=gha \
+            --cache-from type=local,src=/tmp/.buildx-cache \
             --cache-to type=gha,mode=max \
+            --cache-to type=local,dest=/tmp/.buildx-cache-new,mode=max \
             -t $ECR_REGISTRY/yourssu/${{ vars.PROJECT_NAME }}:$IMAGE_TAG \
             -t $ECR_REGISTRY/yourssu/${{ vars.PROJECT_NAME }}:latest \
             .
+          
+          # 캐시 교체
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
       - name: Deploy to EC2
         env:

--- a/observer/script/observer.py
+++ b/observer/script/observer.py
@@ -125,7 +125,7 @@ if __name__ == "__main__":
     # (같은 날 재시작 시 기존 내용을 신규 로그로 오인하지 않도록)
     for existing_log in glob.glob(os.path.join(path, "**/*.log"), recursive=True):
         try:
-            with open(existing_log, "r", encoding="utf-8") as f:
+            with open(existing_log, "r", encoding="utf-8", errors="ignore") as f:
                 last_checked_line[existing_log] = len(f.readlines())
         except Exception:
             pass


### PR DESCRIPTION
## Summary

- `observer.py` 초기 스캔에 `errors="ignore"` 추가

## 원인

이전 컨테이너가 한글(3바이트 UTF-8) 로그 쓰다 종료되면 로그 파일 끝에 불완전 바이트가 남음.
재배포 시 초기 스캔에서 `UnicodeDecodeError` → `except: pass` → 해당 파일이 `last_checked_line` 미등록.

Spring이 Tomcat 기동 로그를 append하면 `check()`에서:
```python
if file_path not in last_checked_line:
    last_checked_line[file_path] = len(lines)  # 현재 전체 줄 수로 초기화
lines = lines[last_checked_line.get(file_path):]  # → 빈 리스트
```
Tomcat 기동 로그가 스킵 → **SERVER RESTARTED 미전송**

DEV는 로그 파일 오염 없거나 새 파일이라 정상 동작. PROD는 이전 컨테이너 잔존 로그 파일 오염으로 재현.

## Test plan

- [ ] PROD 배포 후 Slack `#signal-notifications`에 PROD SERVER RESTARTED 확인
- [ ] 이후 프로필 등록 시 Slack 알림 정상 수신 확인