### PR TITLE
feat: switch local profile to SQLite

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -1,7 +1,8 @@
 # Spring profile
 SPRING_PROFILES_ACTIVE=local
 
-# Database (local uses H2 in-memory, no config needed)
+# Database
+DB_URL=jdbc:sqlite:./build/db/signal-local.db
 
 # Admin
 ADMIN_ACCESS_KEY=your-admin-access-key

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,6 +17,8 @@ val kotestVersion = "5.9.1"
 val jacksonVersion = "2.18.2"
 val h2Version = "2.3.232"
 val mysqlVersion = "9.1.0"
+val sqliteVersion = "3.50.1.0"
+val hibernateCommunityDialectsVersion = "6.6.15.Final"
 val junitPlatformVersion = "1.11.4"
 val guavaVersion = "33.3.0-jre"
 val swaggerVersion = "2.8.3"
@@ -65,6 +67,8 @@ dependencies {
 
     runtimeOnly("com.h2database:h2:$h2Version")
     runtimeOnly("com.mysql:mysql-connector-j:$mysqlVersion")
+    runtimeOnly("org.xerial:sqlite-jdbc:$sqliteVersion")
+    implementation("org.hibernate.orm:hibernate-community-dialects:$hibernateCommunityDialectsVersion")
 
     implementation("com.google.guava:guava:$guavaVersion")
 

--- a/app/src/main/resources/application-local.yml
+++ b/app/src/main/resources/application-local.yml
@@ -1,0 +1,68 @@
+server:
+  port: 9012
+
+spring:
+  config:
+    import: optional:file:.env[.properties]
+
+  cors:
+    allowed-origin: ${CORS_ALLOWED_ORIGIN}
+  datasource:
+    url: ${DB_URL:jdbc:sqlite:./build/db/signal-local.db}
+    driver-class-name: org.sqlite.JDBC
+    hikari:
+      maximum-pool-size: 1
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.community.dialect.SQLiteDialect
+
+domain:
+  permission:
+    admin:
+      access-key: ${ADMIN_ACCESS_KEY}
+      contact-secret-key: ${CONTACT_SECRET_KEY}
+  policy:
+    whitelist: ${WHITELIST}
+    contact-limit: ${CONTACT_LIMIT}
+    contact-limit-warning: ${CONTACT_LIMIT_WARNING}
+    contact-price: ${TICKET_COST}
+    ticket-price-policy: ${TICKET_PRICE_POLICY}
+    ticket-price-registered-policy: ${TICKET_PRICE_REGISTERED_POLICY}
+    banned-words: ${BANNED_WORDS:}
+
+infra:
+  openai:
+    url: ${OPENAI_URL}
+    api-key: ${OPENAI_API_KEY}
+    model: ${OPENAI_MODEL}
+    prompt: ${OPENAI_PROMPT}
+    user-input: ${USER_INPUT_LIMIT}
+  kakaopay:
+    admin-key: ${KAKAOPAY_ADMIN_KEY}
+    cid: ${KAKAOPAY_CID}
+    approval-url: ${KAKAOPAY_APPROVAL_URL}
+    cancel-url: ${KAKAOPAY_CANCEL_URL}
+    fail-url: ${KAKAOPAY_FAIL_URL}
+  google:
+    oauth:
+      client-id: ${GOOGLE_OAUTH_CLIENT_ID:test-google-client-id}
+      client-secret: ${GOOGLE_OAUTH_CLIENT_SECRET}
+      redirect-uri: ${GOOGLE_OAUTH_REDIRECT_URI:http://localhost:9012/auth/google}
+
+jwt:
+  secret: ${JWT_SECRET}
+  access-token-expiration: ${JWT_ACCESS_TOKEN_EXPIRATION}
+  refresh-token-expiration: ${JWT_REFRESH_TOKEN_EXPIRATION}
+
+springdoc:
+  api-docs:
+    path: /api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    tags-sorter: alpha
+    operations-sorter: alpha
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json


### PR DESCRIPTION
## 요약
local 프로파일이 H2 대신 SQLite 파일 DB로 기동되도록 변경했습니다.

## 구현 내용
- `application-local.yml`을 추가해 local 프로파일 전용 SQLite datasource를 설정했습니다.
- local Hibernate dialect를 `org.hibernate.community.dialect.SQLiteDialect`로 설정했습니다.
- 로컬 실행용 기본 DB 경로를 `.env.example`에 `jdbc:sqlite:./build/db/signal-local.db`로 추가했습니다.
- Gradle에 SQLite JDBC와 Hibernate community dialect 의존성을 추가했습니다.

## 검증
- `./gradlew.bat compileKotlin`

## 범위 밖
- `dev`/`prod`/`test` 프로파일은 변경하지 않았습니다.
- SQL 스크립트 기반 초기화는 추가하지 않았습니다.